### PR TITLE
Fix invalid default router.xml (Unterminated XML comment tag)

### DIFF
--- a/etc/router.xml.dist.in
+++ b/etc/router.xml.dist.in
@@ -196,7 +196,7 @@
   </aci>
 
   <!-- Simple message logging to flat file
-       Remove <enabled/> tag to disable logging
+       Remove <enabled/> tag to disable logging -->
   <!--
   <message_logging>
     <enabled/>

--- a/tests/config/config_test.cpp
+++ b/tests/config/config_test.cpp
@@ -25,6 +25,7 @@ class ConfigTest: public CppUnit::TestFixture
     CPPUNIT_TEST(test010);
     CPPUNIT_TEST(test012);
     CPPUNIT_TEST(test013);
+    CPPUNIT_TEST(test_load_all_configs);
     CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -171,6 +172,27 @@ public:
         config_free(c);
     }
 
+    void test_load_all_configs() {
+        const char *generated_configs[] =	{
+            "../../etc/s2s.xml.dist",
+            "../../etc/sm.xml.dist",
+            "../../etc/router.xml.dist",
+            "../../etc/router-filter.xml.dist",
+            "../../etc/templates/roster.xml.dist",
+            "../../etc/c2s.xml.dist",
+            "../../etc/router-users.xml.dist"
+            };
+
+        for (int i = 0; i < sizeof(generated_configs) / sizeof(generated_configs[0]); i++) 
+        {
+            std::stringstream msg;
+            msg << "Faled to load config " << generated_configs[i];
+            config_t c = config_new();
+            CPPUNIT_ASSERT_MESSAGE(msg.str().c_str(), c != 0);
+            CPPUNIT_ASSERT_EQUAL_MESSAGE(msg.str().c_str(), 0, config_load(c, generated_configs[i]));
+            config_free(c);
+        }
+    }
 };
 
 


### PR DESCRIPTION
The issue is introduced by commit:cc284d2d65b6cb169d4e2fe88b8ce0311b483fe0
Unit test is updated to avoid such bugs in future.
