### PR TITLE
Implement debug logging into file

### DIFF
--- a/c2s/main.c
+++ b/c2s/main.c
@@ -85,6 +85,8 @@ static void _c2s_config_expand(c2s_t c2s)
     int i;
     stream_redirect_t sr;
 
+    set_debug_log_from_config(c2s->config);
+
     c2s->id = config_get_one(c2s->config, "id", 0);
     if(c2s->id == NULL)
         c2s->id = "c2s";
@@ -786,6 +788,8 @@ JABBER_MAIN("jabberd2c2s", "Jabber 2 C2S", "Jabber Open Source Server: Client to
         mio_run(c2s->mio, mio_timeout);
 
         if(c2s_logrotate) {
+            set_debug_log_from_config(c2s->config);
+
             log_write(c2s->log, LOG_NOTICE, "reopening log ...");
             log_free(c2s->log);
             c2s->log = log_new(c2s->log_type, c2s->log_ident, c2s->log_facility);

--- a/etc/c2s.xml.dist.in
+++ b/etc/c2s.xml.dist.in
@@ -62,6 +62,11 @@
     <!--
     <file>@localstatedir@/jabberd/log/c2s.log</file>
     -->
+
+    <!-- Filename of the debug logfile -->
+    <!--
+    <debug>@localstatedir@/@package@/log/debug-${id}.log</debug>
+    -->
   </log>
 
   <!-- Local network configuration -->

--- a/etc/router.xml.dist.in
+++ b/etc/router.xml.dist.in
@@ -20,6 +20,11 @@
     <!--
     <file>@localstatedir@/jabberd/log/router.log</file>
     -->
+
+    <!-- Filename of the debug logfile -->
+    <!--
+    <debug>@localstatedir@/@package@/log/debug-${id}.log</debug>
+    -->
   </log>
 
   <!-- Local network configuration -->

--- a/etc/s2s.xml.dist.in
+++ b/etc/s2s.xml.dist.in
@@ -72,6 +72,11 @@
     <!--
     <file>@localstatedir@/jabberd/log/s2s.log</file>
     -->
+
+    <!-- Filename of the debug logfile -->
+    <!--
+    <debug>@localstatedir@/@package@/log/debug-${id}.log</debug>
+    -->
   </log>
 
   <!-- Local network configuration -->

--- a/etc/sm.xml.dist.in
+++ b/etc/sm.xml.dist.in
@@ -62,6 +62,11 @@
     <!--
     <file>@localstatedir@/jabberd/log/sm.log</file>
     -->
+
+    <!-- Filename of the debug logfile -->
+    <!--
+    <debug>@localstatedir@/@package@/log/debug-${id}.log</debug>
+    -->
   </log>
 
   <!-- Local network configuration -->

--- a/router/main.c
+++ b/router/main.c
@@ -83,6 +83,8 @@ static void _router_config_expand(router_t r)
     if(r->id == NULL)
         r->id = "router";
 
+    set_debug_log_from_config(r->config);
+
     r->log_type = log_STDOUT;
     if(config_get(r->config, "log") != NULL) {
         if((str = config_get_attr(r->config, "log", 0, "type")) != NULL) {
@@ -445,6 +447,8 @@ JABBER_MAIN("jabberd2router", "Jabber 2 Router", "Jabber Open Source Server: Rou
 
         if(router_logrotate)
         {
+            set_debug_log_from_config(r->config);
+
             log_write(r->log, LOG_NOTICE, "reopening log ...");
             log_free(r->log);
             r->log = log_new(r->log_type, r->log_ident, r->log_facility);

--- a/s2s/main.c
+++ b/s2s/main.c
@@ -79,6 +79,8 @@ static void _s2s_config_expand(s2s_t s2s) {
     config_elem_t elem;
     int i, r;
 
+    set_debug_log_from_config(s2s->config);
+
     s2s->id = config_get_one(s2s->config, "id", 0);
     if(s2s->id == NULL)
         s2s->id = "s2s";
@@ -979,6 +981,8 @@ JABBER_MAIN("jabberd2s2s", "Jabber 2 S2S", "Jabber Open Source Server: Server to
         now = time(NULL);
 
         if(s2s_logrotate) {
+            set_debug_log_from_config(s2s->config);
+
             log_write(s2s->log, LOG_NOTICE, "reopening log ...");
             log_free(s2s->log);
             s2s->log = log_new(s2s->log_type, s2s->log_ident, s2s->log_facility);

--- a/sm/main.c
+++ b/sm/main.c
@@ -105,6 +105,8 @@ static void _sm_config_expand(sm_t sm)
     char *str;
     config_elem_t elem;
 
+    set_debug_log_from_config(sm->config);
+
     sm->id = config_get_one(sm->config, "id", 0);
     if(sm->id == NULL)
         sm->id = "sm";
@@ -396,6 +398,8 @@ JABBER_MAIN("jabberd2sm", "Jabber 2 Session Manager", "Jabber Open Source Server
         mio_run(sm->mio, 5);
 
         if(sm_logrotate) {
+            set_debug_log_from_config(sm->config);
+
             log_write(sm->log, LOG_NOTICE, "reopening log ...");
             log_free(sm->log);
             sm->log = log_new(sm->log_type, sm->log_ident, sm->log_facility);

--- a/util/log.c
+++ b/util/log.c
@@ -24,6 +24,7 @@
 
 #ifdef DEBUG
 static int debug_flag;
+static FILE *debug_log_target = 0;
 #endif
 
 static const char *_log_level[] =
@@ -159,10 +160,13 @@ void log_write(log_t log, int level, const char *msgfmt, ...)
 #endif
 
 #ifdef DEBUG
+    if (!debug_log_target) {
+        debug_log_target = stderr;
+    }
     /* If we are in debug mode we want everything copied to the stdout */
     if ((log == 0) || (get_debug_flag() && log->type != log_STDOUT)) {
-        fprintf(stdout, "%s\n", message);
-        fflush(stdout);
+        fprintf(debug_log_target, "%s\n", message);
+        fflush(debug_log_target);
     }
 #endif /*DEBUG*/
 }
@@ -185,6 +189,9 @@ void debug_log(const char *file, int line, const char *msgfmt, ...)
     int sz;
     time_t t;
 
+    if (!debug_log_target) {
+        debug_log_target = stderr;
+    }
     /* timestamp */
     t = time(NULL);
     pos = ctime(&t);
@@ -201,9 +208,9 @@ void debug_log(const char *file, int line, const char *msgfmt, ...)
     va_start(ap, msgfmt);
     vsnprintf(pos, MAX_DEBUG - sz, msgfmt, ap);
     va_end(ap);
-    fprintf(stderr,"%s", message);
-    fprintf(stderr, "\n");
-    fflush(stderr);
+    fprintf(debug_log_target,"%s", message);
+    fprintf(debug_log_target, "\n");
+    fflush(debug_log_target);
 }
 
 int get_debug_flag(void)
@@ -215,6 +222,41 @@ void set_debug_flag(int v)
 {
     debug_flag = v;
 }
+
+int set_debug_log_from_config(config_t c)
+{
+    return set_debug_file(config_get_one(c, "log.debug", 0));
+};
+
+JABBERD2_API int set_debug_file(const char *filename)
+{
+    // Close debug output file but not stderr
+    if (debug_log_target != 0 &&
+        debug_log_target != stderr)
+    {
+        fprintf(debug_log_target, "Closing log\n");
+        fclose(debug_log_target);
+
+        debug_log_target = stderr;
+    }
+
+    // Setup new log target
+    if (filename) {
+        log_debug(ZONE, "Openning debug log file %s", filename);
+        debug_log_target = fopen(filename, "a+");
+
+        if (debug_log_target) {
+            log_debug(ZONE, "Staring debug log");
+        } else {
+            debug_log_target = stderr;
+            log_debug(ZONE, "Failed to open debug output file %s. Fallback to stderr", filename);
+        }
+    } else {
+        // set stderr
+        debug_log_target = stderr;
+    }
+};
+
 #else /* DEBUG */
 void debug_log(const char *file, int line, const char *msgfmt, ...)
 { }

--- a/util/util.h
+++ b/util/util.h
@@ -414,6 +414,10 @@ JABBERD2_API int hex_to_raw(char *in, int inlen, char *out);
 JABBERD2_API int get_debug_flag(void);
 JABBERD2_API void set_debug_flag(int v);
 JABBERD2_API void debug_log(const char *file, int line, const char *msgfmt, ...);
+JABBERD2_API int set_debug_file(const char *filename);
+
+JABBERD2_API int set_debug_log_from_config(config_t c);
+
 #define ZONE __FILE__,__LINE__
 #define MAX_DEBUG 8192
 


### PR DESCRIPTION
Debug log file is now configured by log.debug configuration element.
If not specified, stderr is used as debug output target.
The output of log_write function is now duplicated into debug stream, not stdout.

Debug output file supports logrotate by SIGHUP
