### PR TITLE
Utilize XML_SetHashSalt

### DIFF
--- a/sx/sx.c
+++ b/sx/sx.c
@@ -19,6 +19,7 @@
  */
 
 #include "sx.h"
+#include <time.h>
 
 sx_t sx_new(sx_env_t env, int tag, sx_callback_t cb, void *arg) {
     sx_t s;
@@ -45,6 +46,10 @@ sx_t sx_new(sx_env_t env, int tag, sx_callback_t cb, void *arg) {
     XML_SetEntityDeclHandler(s->expat, (void *) _sx_entity_declaration);
 #else
     XML_SetDefaultHandler(s->expat, NULL);
+#endif
+
+#ifdef HAVE_XML_SETHASHSALT
+    XML_SetHashSalt(s->expat, clock());
 #endif
 
     s->wbufq = jqueue_new();

--- a/util/util.h
+++ b/util/util.h
@@ -450,6 +450,7 @@ JABBERD2_API int jabber_wrap_service(int argc, char** argv, jmainhandler_t *wrap
 #if XML_MAJOR_VERSION > 1
 /* XML_StopParser is present in expat 2.x */
 #define HAVE_XML_STOPPARSER
+#define HAVE_XML_SETHASHSALT
 #endif
 
 /* define TRUE and FALSE if not yet defined */


### PR DESCRIPTION
It is a prelimnary fix for multiple calls of srand() with expat-2.1.0

Captured from mail thread:

> > Anyway, I suspect you blame the following expat's function:
> > 
> > static unsigned long
> > generate_hash_secret_salt(void)
> > {
> >   unsigned int seed = time(NULL) % UINT_MAX;
> >   srand(seed);
> >   return rand();
> > }
> > 
> > It is called once (per parser instance) with quite random value
> > based on current time.
> > That's the mostly recommended way  to initialize pseudo-random
> > generator as far as I remember
> > so it looks safe for me.
> 
> No, the problem is that jabberd2 creates a new parser for each
> connection and needs a random id for each connection. Now if there are
> 2 connections within a second, the random number generator gets
> reseeded with the same initial value and you get the same random id
> for both connections.

The fix is the call of XML_SetHashSalt (as suggested by expat) for each XML_Parser instance so srand() is not even called.

The only doubt with this patch is using clock(). It has about 1 ms granularity
so two call within 1 ms may have the same hash salt.

It is much better than 1 sec granularity of time() but anyway..

Lets test this patch.
