### PR TITLE
Fix s2s crash with whitelist enabled

### DIFF
--- a/etc/s2s.xml.dist.in
+++ b/etc/s2s.xml.dist.in
@@ -302,6 +302,13 @@
       <require_tls/>
     -->
 
+    <!--
+        Domain whitelisting
+    -->
+    <!--
+    <enable_whitelist/>
+    -->
+
     <!-- Domain whitelisting
          When defined, only whitelisted domains are allowed to connect -->
     <!--

--- a/s2s/main.c
+++ b/s2s/main.c
@@ -746,7 +746,7 @@ int s2s_domain_in_whitelist(s2s_t s2s, char *in_domain) {
         *dst = (char *)malloc(seg_tmp_len + 1);
         if (*dst != NULL) {
             strncpy(*dst, seg_tmp, seg_tmp_len + 1);
-            dst[seg_tmp_len] = '\0';
+            (*dst)[seg_tmp_len] = '\0';
         } else { 
             if (seg_tmp != NULL) {
                 free(seg_tmp);


### PR DESCRIPTION
Two issues was reported in mailing lists by Clint Eastwood mpxhack@gmail.com

Two observations about the s2s whitelist feature:
- I guess we should add a comment on the s2s.xml template file about the
  necessity of <enable_whitelist/> tag. I had to look at the source code to
  figure out it was needed.
- When the whitelist feature was enabled, s2s started to crash and
  generate core dumps. I digged into the code and used valgrind to get to the
  problem.
