### PR TITLE
Fix compilation warnings

### DIFF
--- a/c2s/authreg.c
+++ b/c2s/authreg.c
@@ -37,8 +37,9 @@ typedef struct _authreg_error_st {
 } *authreg_error_t;
 
 /** get a handle for the named module */
-authreg_t authreg_init(c2s_t c2s, char *name) {
-    char mod_fullpath[PATH_MAX], *modules_path;
+authreg_t authreg_init(c2s_t c2s, const char *name) {
+    char mod_fullpath[PATH_MAX];
+    const char *modules_path;
     ar_module_init_fn init_fn = NULL;
     authreg_t ar;
     void *handle;
@@ -120,7 +121,7 @@ void authreg_free(authreg_t ar) {
 }
 
 /** auth logger */
-inline static void _authreg_auth_log(c2s_t c2s, sess_t sess, char *method, char *username, char *resource, int success) {
+inline static void _authreg_auth_log(c2s_t c2s, sess_t sess, const char *method, const char *username, const char *resource, int success) {
     log_write(c2s->log, LOG_NOTICE, "[%d] %s authentication %s: %s@%s/%s %s:%d%s%s",
         sess->s->tag, method, success ? "succeeded" : "failed",
         username, sess->host->realm, resource,

--- a/c2s/c2s.c
+++ b/c2s/c2s.c
@@ -507,7 +507,7 @@ static int _c2s_client_sx_callback(sx_t s, sx_event_t e, void *data, void *arg) 
     return 0;
 }
 
-static int _c2s_client_accept_check(c2s_t c2s, mio_fd_t fd, char *ip) {
+static int _c2s_client_accept_check(c2s_t c2s, mio_fd_t fd, const char *ip) {
     rate_t rt;
 
     if(access_check(c2s->access, ip) == 0) {
@@ -539,7 +539,8 @@ static int _c2s_client_mio_callback(mio_t m, mio_action_t a, mio_fd_t fd, void *
     c2s_t c2s = (c2s_t) arg;
     bres_t bres;
     struct sockaddr_storage sa;
-    int namelen = sizeof(sa), port, nbytes, flags = 0;
+    socklen_t namelen = sizeof(sa);
+    int port, nbytes, flags = 0;
 
     switch(a) {
         case action_READ:
@@ -705,6 +706,7 @@ int c2s_router_sx_callback(sx_t s, sx_event_t e, void *data, void *arg) {
     char skey[44];
     sess_t sess;
     bres_t bres, ires;
+    char *smcomp;
 
     switch(e) {
         case event_WANT_READ:
@@ -978,7 +980,7 @@ int c2s_router_sx_callback(sx_t s, sx_event_t e, void *data, void *arg) {
                     target = nad_find_attr(nad, 1, -1, "target", NULL);
                     smid = nad_find_attr(nad, 1, ns, "sm", NULL);
                     if(target < 0 || smid < 0) {
-                        char *buf;
+                        const char *buf;
                         int len;
                         nad_print(nad, 0, &buf, &len);
                         log_write(c2s->log, LOG_NOTICE, "sm sent an invalid start packet: %.*s", len, buf );
@@ -1261,8 +1263,11 @@ int c2s_router_sx_callback(sx_t s, sx_event_t e, void *data, void *arg) {
 
                     /* and remember the SM that services us */
                     from = nad_find_attr(nad, 0, -1, "from", NULL);
-                    sess->smcomp = malloc(NAD_AVAL_L(nad, from) + 1);
-                    snprintf(sess->smcomp, NAD_AVAL_L(nad, from) + 1, "%.*s", NAD_AVAL_L(nad, from), NAD_AVAL(nad, from));
+                    
+                    
+                    smcomp = malloc(NAD_AVAL_L(nad, from) + 1);
+                    snprintf(smcomp, NAD_AVAL_L(nad, from) + 1, "%.*s", NAD_AVAL_L(nad, from), NAD_AVAL(nad, from));
+                    sess->smcomp = smcomp;
 
                     nad_free(nad);
 

--- a/c2s/c2s.h
+++ b/c2s/c2s.h
@@ -78,9 +78,9 @@ struct sess_st {
 
     char                skey[44];
 
-    char                *smcomp; /* sm component servicing this session */
+    const char          *smcomp; /* sm component servicing this session */
 
-    char                *ip;
+    const char          *ip;
     int                 port;
 
     sx_t                s;
@@ -116,13 +116,13 @@ struct sess_st {
 
 struct host_st {
     /** our realm (SASL) */
-    char                *realm;
+    const char          *realm;
 
     /** starttls pemfile */
-    char                *host_pemfile;
+    const char          *host_pemfile;
 
     /** certificate chain */
-    char                *host_cachain;
+    const char          *host_cachain;
 
     /** verify-mode  */
     int                 host_verify_mode;
@@ -132,22 +132,22 @@ struct host_st {
 
     /** registration */
     int                 ar_register_enable;
-    char                *ar_register_instructions;
-    char                *ar_register_oob;
+    const char          *ar_register_instructions;
+    const char          *ar_register_oob;
     int                 ar_register_password;
 
 };
 
 struct c2s_st {
     /** our id (hostname) with the router */
-    char                *id;
+    const char          *id;
 
     /** how to connect to the router */
-    char                *router_ip;
+    const char          *router_ip;
     int                 router_port;
-    char                *router_user;
-    char                *router_pass;
-    char                *router_pemfile;
+    const char          *router_user;
+    const char          *router_pass;
+    const char          *router_pemfile;
 
     /** mio context */
     mio_t               mio;
@@ -178,12 +178,12 @@ struct c2s_st {
 
     /** log data */
     log_type_t          log_type;
-    char                *log_facility;
-    char                *log_ident;
+    const char          *log_facility;
+    const char          *log_ident;
 
     /** packet counter */
     long long int       packet_count;
-    char                *packet_stats;
+    const char          *packet_stats;
 
     /** connect retry */
     int                 retry_init;
@@ -192,7 +192,7 @@ struct c2s_st {
     int                 retry_left;
 
     /** ip to listen on */
-    char                *local_ip;
+    const char          *local_ip;
 
     /** unencrypted port */
     int                 local_port;
@@ -201,19 +201,19 @@ struct c2s_st {
     int                 local_ssl_port;
 
     /** encrypted port pemfile */
-    char                *local_pemfile;
+    const char          *local_pemfile;
 
     /** encrypted port cachain file */
-    char                *local_cachain;
+    const char          *local_cachain;
 
     /** verify-mode  */
     int                 local_verify_mode;
 
     /** http forwarding URL */
-    char                *http_forward;
+    const char          *http_forward;
 
     /** PBX integration named pipe */
-    char                *pbx_pipe;
+    const char          *pbx_pipe;
     int                 pbx_pipe_fd;
     mio_fd_t            pbx_pipe_mio_fd;
 
@@ -234,7 +234,7 @@ struct c2s_st {
     time_t              next_check;
 
     /** auth/reg module */
-    char                *ar_module_name;
+    const char          *ar_module_name;
     authreg_t           ar;
 
     /** allowed mechanisms */
@@ -307,31 +307,31 @@ struct authreg_st
     void        *private;
 
     /** returns 1 if the user exists, 0 if not */
-    int         (*user_exists)(authreg_t ar, char *username, char *realm);
+    int         (*user_exists)(authreg_t ar, const char *username, const char *realm);
 
     /** return this users cleartext password in the array (digest auth, password auth) */
-    int         (*get_password)(authreg_t ar, char *username, char *realm, char password[257]);
+    int         (*get_password)(authreg_t ar, const char *username, const char *realm, char password[257]);
 
     /** check the given password against the stored password, 0 if equal, !0 if not equal (password auth) */
-    int         (*check_password)(authreg_t ar, char *username, char *realm, char password[257]);
+    int         (*check_password)(authreg_t ar, const char *username, const char *realm, char password[257]);
 
     /** store this password (register) */
-    int         (*set_password)(authreg_t ar, char *username, char *realm, char password[257]);
+    int         (*set_password)(authreg_t ar, const char *username, const char *realm, char password[257]);
 
     /** make or break the user (register / register remove) */
-    int         (*create_user)(authreg_t ar, char *username, char *realm);
-    int         (*delete_user)(authreg_t ar, char *username, char *realm);
+    int         (*create_user)(authreg_t ar, const char *username, const char *realm);
+    int         (*delete_user)(authreg_t ar, const char *username, const char *realm);
 
     void        (*free)(authreg_t ar);
 
     /* Additions at the end - to preserve offsets for existing modules */
 
     /** returns 1 if the user is permitted to authorize as the requested_user, 0 if not. requested_user is a JID */
-    int               (*user_authz_allowed)(authreg_t ar, char *username, char *realm, char *requested_user);
+    int               (*user_authz_allowed)(authreg_t ar, const char *username, const char *realm, const char *requested_user);
 };
 
 /** get a handle for a single module */
-C2S_API authreg_t   authreg_init(c2s_t c2s, char *name);
+C2S_API authreg_t   authreg_init(c2s_t c2s, const char *name);
 
 /** shut down */
 C2S_API void        authreg_free(authreg_t ar);
@@ -343,12 +343,12 @@ typedef int (*ar_module_init_fn)(authreg_t);
 C2S_API int         authreg_process(c2s_t c2s, sess_t sess, nad_t nad);
 
 /*
-int     authreg_user_exists(authreg_t ar, char *username, char *realm);
-int     authreg_get_password(authreg_t ar, char *username, char *realm, char password[257]);
-int     authreg_check_password(authreg_t ar, char *username, char *realm, char password[257]);
-int     authreg_set_password(authreg_t ar, char *username, char *realm, char password[257]);
-int     authreg_create_user(authreg_t ar, char *username, char *realm);
-int     authreg_delete_user(authreg_t ar, char *username, char *realm);
+int     authreg_user_exists(authreg_t ar, const char *username, const char *realm);
+int     authreg_get_password(authreg_t ar, const char *username, const char *realm, char password[257]);
+int     authreg_check_password(authreg_t ar, const char *username, const char *realm, char password[257]);
+int     authreg_set_password(authreg_t ar, const char *username, const char *realm, char password[257]);
+int     authreg_create_user(authreg_t ar, const char *username, const char *realm);
+int     authreg_delete_user(authreg_t ar, const char *username, const char *realm);
 void    authreg_free(authreg_t ar);
 */
 
@@ -356,14 +356,14 @@ void    authreg_free(authreg_t ar);
 union xhashv
 {
   void **val;
-  char **char_val;
+  const char **char_val;
   sess_t *sess_val;
 };
 
 // Data for stream redirect errors
 typedef struct stream_redirect_st
 {
-    char *to_address;
-    char *to_port;
+    const char *to_address;
+    const char *to_port;
 } *stream_redirect_t;
 

--- a/c2s/main.c
+++ b/c2s/main.c
@@ -51,7 +51,7 @@ static void _c2s_signal_usr2(int signum)
 
 /** store the process id */
 static void _c2s_pidfile(c2s_t c2s) {
-    char *pidfile;
+    const char *pidfile;
     FILE *f;
     pid_t pid;
 
@@ -79,7 +79,7 @@ static void _c2s_pidfile(c2s_t c2s) {
 /** pull values out of the config file */
 static void _c2s_config_expand(c2s_t c2s)
 {
-    char *str, *ip, *mask;
+    const char *str, *ip, *mask;
     char *req_domain, *to_address, *to_port;
     config_elem_t elem;
     int i;
@@ -389,7 +389,7 @@ static int _c2s_router_connect(c2s_t c2s) {
 
 static int _c2s_sx_sasl_callback(int cb, void *arg, void **res, sx_t s, void *cbarg) {
     c2s_t c2s = (c2s_t) cbarg;
-    char *my_realm, *mech;
+    const char *my_realm, *mech;
     sx_sasl_creds_t creds;
     static char buf[3072];
     char mechbuf[256];
@@ -873,8 +873,8 @@ JABBER_MAIN("jabberd2c2s", "Jabber 2 C2S", "Jabber Open Source Server: Client to
             sess = (sess_t) jqueue_pull(c2s->dead_sess);
 
             /* free sess data */
-            if(sess->ip != NULL) free(sess->ip);
-            if(sess->smcomp != NULL) free(sess->smcomp);
+            if(sess->ip != NULL) free((void*)sess->ip);
+            if(sess->smcomp != NULL) free((void*)sess->smcomp);
             if(sess->result != NULL) nad_free(sess->result);
             if(sess->resources != NULL)
                 for(res = sess->resources; res != NULL;) {
@@ -944,7 +944,7 @@ JABBER_MAIN("jabberd2c2s", "Jabber 2 C2S", "Jabber Open Source Server: Client to
         sess = (sess_t) jqueue_pull(c2s->dead_sess);
 
         /* free sess data */
-        if(sess->ip != NULL) free(sess->ip);
+        if(sess->ip != NULL) free((void*)sess->ip);
         if(sess->result != NULL) nad_free(sess->result);
         if(sess->resources != NULL)
             for(res = sess->resources; res != NULL;) {

--- a/c2s/pbx.c
+++ b/c2s/pbx.c
@@ -32,7 +32,7 @@ static void _pbx_close_pipe(c2s_t c2s);
 static void _pbx_open_pipe(c2s_t c2s, int mode);
 static void _pbx_read_pipe(c2s_t c2s);
 static void _pbx_write_pipe(c2s_t c2s);
-int _pbx_process_command(c2s_t c2s, char *cmd);
+int _pbx_process_command(c2s_t c2s, const char *cmd);
 
 static void _pbx_read_command(c2s_t c2s) {
 	char buf[COMMANDLINE_LENGTH_MAX];

--- a/c2s/pbx_commands.c
+++ b/c2s/pbx_commands.c
@@ -36,14 +36,14 @@
 
 #include "c2s.h"
 
-static int _pbx_command_part_len(char *cmd)
+static int _pbx_command_part_len(const char *cmd)
 {
 	int i;
 	for(i=0; *cmd != ' ' && *cmd != '\t' && *cmd != '\n' && *cmd != '\0'; cmd++, i++);
 	return i;
 }
 
-static nad_t _pbx_presence_nad(int available, char *cmd)
+static nad_t _pbx_presence_nad(int available, const char *cmd)
 {
 	nad_t nad;
 	int ns;
@@ -115,7 +115,7 @@ static nad_t _pbx_presence_nad(int available, char *cmd)
  * process commandline
  * @return: 0 to indicate that output needs to be written
  */
-int _pbx_process_command(c2s_t c2s, char *cmd)
+int _pbx_process_command(c2s_t c2s, const char *cmd)
 {
 	jid_t jid;
 	int action = 0, len;

--- a/c2s/sm.c
+++ b/c2s/sm.c
@@ -31,7 +31,7 @@ static void _sm_generate_id(sess_t sess, bres_t res, const char *type) {
 }
 
 /** make a new action route */
-static nad_t _sm_build_route(sess_t sess, bres_t res, const char *action, const char *target, char *id) {
+static nad_t _sm_build_route(sess_t sess, bres_t res, const char *action, const char *target, const char *id) {
     nad_t nad;
     int ns, ans;
 

--- a/configure.ac
+++ b/configure.ac
@@ -936,6 +936,9 @@ if test "x-$want_tests" = "x-yes" ; then
 fi
 AM_CONDITIONAL(ENABLE_TESTS, [test "x-$want_tests" = "x-yes"])
 
+AC_ARG_ENABLE([werror], AC_HELP_STRING([--enable-werror], [Treat all warnings as error]),
+              CFLAGS="-Wall -Werror -Wno-unused-result -Wno-pointer-sign -Wno-strict-overflow $CFLAGS")
+
 # Generate Makefiles
 AC_CONFIG_FILES([Doxyfile
                  Makefile

--- a/docs/dev/programmers-guide.xml
+++ b/docs/dev/programmers-guide.xml
@@ -190,7 +190,7 @@
     <itemizedlist>
 
       <listitem>
-        <para><command>int mio_connect(mio_t m, int port, char *hostip, mio_handler_t app, void *arg)</command></para>
+        <para><command>int mio_connect(mio_t m, int port, const char *hostip, mio_handler_t app, void *arg)</command></para>
         <para><command>mio_connect()</command> initiates a connection to the given ip/port. This function returns immediately, and the connect continues in the background (in non-blocking mode). The application should call <link linkend='mio-check'><command>mio_read()</command></link> and/or <link linkend='mio-check'><command>mio_write()</command></link> after calling <command>mio_connect()</command> in order to receive events after the connection has completed.</para>
         <para>If the connect fails, the callback will be called with the <command>action_CLOSE</command> event.</para>
         <para>This function takes the following arguments:</para>
@@ -209,7 +209,7 @@
       </listitem>
 
       <listitem>
-        <para><command>int mio_listen(mio_t m, int port, char *sourceip, mio_handler_t app, void *arg)</command></para>
+        <para><command>int mio_listen(mio_t m, int port, const char *sourceip, mio_handler_t app, void *arg)</command></para>
         <para><command>mio_listen()</command> starts a listening socket on the given ip/port. The callback will be called with the <command>action_ACCEPT</command> action when a new connection is initiated.</para>
         <para>This function takes the following arguments:</para>
         <itemizedlist>
@@ -292,11 +292,11 @@
       <itemizedlist>
 
         <listitem>
-          <para><command>int access_allow(access_t access, char *ip, char *mask)</command></para>
+          <para><command>int access_allow(access_t access, const char *ip, const char *mask)</command></para>
         </listitem>
 
         <listitem>
-          <para><command>int access_deny(access_t access, char *ip, char *mask)</command></para>
+          <para><command>int access_deny(access_t access, const char *ip, const char *mask)</command></para>
         </listitem>
       
       </itemizedlist>
@@ -308,7 +308,7 @@
       <itemizedlist>
 
         <listitem>
-          <para><command>int access_check(access_t access, char *ip)</command></para>
+          <para><command>int access_check(access_t access, const char *ip)</command></para>
         </listitem>
 
       </itemizedlist>
@@ -345,7 +345,7 @@
       <itemizedlist>
 
         <listitem>
-          <para><command>log_t log_new(int syslog, char *ident, int facility)</command></para>
+          <para><command>log_t log_new(int syslog, const char *ident, int facility)</command></para>
         </listitem>
 
         <listitem>
@@ -447,11 +447,11 @@
       <itemizedlist>
 
         <listitem>
-          <para><command>int ser_string_get(char **dest, int *source, char *buf, int len)</command></para>
+          <para><command>int ser_string_get(char **dest, int *source, const char *buf, int len)</command></para>
         </listitem>
 
         <listitem>
-          <para><command>int ser_int_get(int *dest, int *source, char *buf, int len)</command></para>
+          <para><command>int ser_int_get(int *dest, int *source, const char *buf, int len)</command></para>
         </listitem>
       
       </itemizedlist>
@@ -462,11 +462,11 @@
       <itemizedlist>
 
         <listitem>
-          <para><command>void ser_string_set(char *source, int *dest, char **buf, int *len)</command></para>
+          <para><command>void ser_string_set(char *source, int *dest, const char **buf, int *len)</command></para>
         </listitem>
 
         <listitem>
-          <para><command>void ser_int_set(int source, int *dest, char **buf, int *len)</command></para>
+          <para><command>void ser_int_set(int source, int *dest, const char **buf, int *len)</command></para>
         </listitem>
       
       </itemizedlist>
@@ -527,7 +527,7 @@
       <itemizedlist>
 
         <listitem>
-          <para><command>void spool_add(spool s, char *str)</command></para>
+          <para><command>void spool_add(spool s, const char *str)</command></para>
         </listitem>
 
         <listitem>

--- a/mio/mio.h
+++ b/mio/mio.h
@@ -110,11 +110,11 @@ typedef struct mio_st
 {
   void (*mio_free)(struct mio_st **m);
 
-  struct mio_fd_st *(*mio_listen)(struct mio_st **m, int port, char *sourceip,
+  struct mio_fd_st *(*mio_listen)(struct mio_st **m, int port, const char *sourceip,
 				  mio_handler_t app, void *arg);
 
-  struct mio_fd_st *(*mio_connect)(struct mio_st **m, int port, char *hostip,
-				   char *srcip, mio_handler_t app, void *arg);
+  struct mio_fd_st *(*mio_connect)(struct mio_st **m, int port, const char *hostip,
+				   const char *srcip, mio_handler_t app, void *arg);
 
   struct mio_fd_st *(*mio_register)(struct mio_st **m, int fd,
 				   mio_handler_t app, void *arg);

--- a/mio/mio_impl.h
+++ b/mio/mio_impl.h
@@ -324,7 +324,7 @@ static void _mio_write(mio_t m, mio_fd_t fd)
 }
 
 /** set up a listener in this mio w/ this default app/arg */
-static mio_fd_t _mio_listen(mio_t m, int port, char *sourceip, mio_handler_t app, void *arg)
+static mio_fd_t _mio_listen(mio_t m, int port, const char *sourceip, mio_handler_t app, void *arg)
 {
     int fd, flag = 1;
     mio_fd_t mio_fd;
@@ -377,7 +377,7 @@ static mio_fd_t _mio_listen(mio_t m, int port, char *sourceip, mio_handler_t app
 }
 
 /** create an fd and connect to the given ip/port */
-static mio_fd_t _mio_connect(mio_t m, int port, char *hostip, char *srcip, mio_handler_t app, void *arg)
+static mio_fd_t _mio_connect(mio_t m, int port, const char *hostip, const char *srcip, mio_handler_t app, void *arg)
 {
     int fd, flag, flags;
     mio_fd_t mio_fd;

--- a/router/filter.c
+++ b/router/filter.c
@@ -40,7 +40,7 @@ void filter_unload(router_t r) {
 }
 
 int filter_load(router_t r) {
-    char *filterfile;
+    const char *filterfile;
     FILE *f;
     long size;
     char *buf;

--- a/router/main.c
+++ b/router/main.c
@@ -45,7 +45,7 @@ static void router_signal_usr2(int signum)
 
 /** store the process id */
 static void _router_pidfile(router_t r) {
-    char *pidfile;
+    const char *pidfile;
     FILE *f;
     pid_t pid;
 
@@ -74,9 +74,9 @@ static void _router_pidfile(router_t r) {
 /** pull values out of the config file */
 static void _router_config_expand(router_t r)
 {
-    char *str, *ip, *mask, *name, *target;
+    const char *str, *ip, *mask, *name, *target;
     config_elem_t elem;
-    int i, len;
+    int i;
     alias_t alias;
 
     r->id = config_get_one(r->config, "id", 0);

--- a/router/router.h
+++ b/router/router.h
@@ -67,7 +67,7 @@ struct acl_s {
 
 struct router_st {
     /** our id */
-    char                *id;
+    const char          *id;
 
     /** config */
     config_t            config;
@@ -85,14 +85,14 @@ struct router_st {
 
     /** log data */
     log_type_t          log_type;
-    char                *log_facility;
-    char                *log_ident;
+    const char          *log_facility;
+    const char          *log_ident;
 
     /** how we listen for stuff */
-    char                *local_ip;
+    const char          *local_ip;
     int                 local_port;
-    char                *local_secret;
-    char                *local_pemfile;
+    const char          *local_secret;
+    const char          *local_pemfile;
 
     /** max file descriptors */
     int                 io_max_fds;
@@ -136,7 +136,7 @@ struct router_st {
     xht                 routes;
 
     /** default route, only one */
-    char                *default_route;
+    const char          *default_route;
 
     /** log sinks, key is route name, var is component_t */
     xht                 log_sinks;
@@ -158,7 +158,7 @@ struct router_st {
 
     /** simple message logging */
 	int message_logging_enabled;
-	char *message_logging_file;
+	const char *message_logging_file;
 };
 
 /** a single component */
@@ -204,15 +204,15 @@ typedef enum {
 
 struct routes_st
 {
-    char                *name;
+    const char          *name;
     route_type_t        rtype;
     component_t         *comp;
     int                 ncomp;
 };
 
 struct alias_st {
-    char                *name;
-    char                *target;
+    const char          *name;
+    const char          *target;
 
     alias_t             next;
 };

--- a/router/user.c
+++ b/router/user.c
@@ -23,7 +23,7 @@
 /** user table manager */
 
 int user_table_load(router_t r) {
-    char *userfile;
+    const char *userfile;
     FILE *f;
     long size;
     char *buf;

--- a/s2s/in.c
+++ b/s2s/in.c
@@ -64,7 +64,8 @@ int in_mio_callback(mio_t m, mio_action_t a, mio_fd_t fd, void *data, void *arg)
     conn_t in = (conn_t) arg;
     s2s_t s2s = (s2s_t) arg;
     struct sockaddr_storage sa;
-    int namelen = sizeof(sa), port, nbytes, flags = 0;
+    socklen_t namelen = sizeof(sa);
+    int port, nbytes, flags = 0;
     char ipport[INET6_ADDRSTRLEN + 17];
 
     switch(a) {
@@ -250,7 +251,7 @@ static int _in_sx_callback(sx_t s, sx_event_t e, void *data, void *arg) {
 
                    /* remove the initial (non-SSL) stream id from the in connections hash */
                    xhash_zap(in->s2s->in, in->key);
-                   free(in->key);
+                   free((void*)in->key);
                 }
 
                 in->key = strdup(s->id);

--- a/s2s/s2s.h
+++ b/s2s/s2s.h
@@ -45,13 +45,13 @@ typedef struct dnsres_st    *dnsres_t;
 
 struct host_st {
     /** our realm */
-    char                *realm;
+    const char          *realm;
 
     /** starttls pemfile */
-    char                *host_pemfile;
+    const char          *host_pemfile;
 
     /** certificate chain */
-    char                *host_cachain;
+    const char          *host_cachain;
 
     /** verify-mode  */
     int                 host_verify_mode;
@@ -59,14 +59,14 @@ struct host_st {
 
 struct s2s_st {
     /** our id (hostname) with the router */
-    char                *id;
+    const char          *id;
 
     /** how to connect to the router */
-    char                *router_ip;
+    const char          *router_ip;
     int                 router_port;
-    char                *router_user;
-    char                *router_pass;
-    char                *router_pemfile;
+    const char          *router_user;
+    const char          *router_pass;
+    const char          *router_pemfile;
     int                 router_default;
 
     /** mio context */
@@ -93,12 +93,12 @@ struct s2s_st {
 
     /** log data */
     log_type_t          log_type;
-    char                *log_facility;
-    char                *log_ident;
+    const char          *log_facility;
+    const char          *log_ident;
 
     /** packet counter */
     long long int       packet_count;
-    char                *packet_stats;
+    const char          *packet_stats;
 
     /** connect retry */
     int                 retry_init;
@@ -107,21 +107,21 @@ struct s2s_st {
     int                 retry_left;
 
     /** ip/port to listen on */
-    char                *local_ip;
+    const char          *local_ip;
     int                 local_port;
 
     /** ip(s) to originate connections from */
-    char                **origin_ips;
+    const char          **origin_ips;
     int                 origin_nips;
 
     /** dialback secret */
-    char                *local_secret;
+    const char          *local_secret;
 
     /** pemfile for peer connections */
-    char                *local_pemfile;
+    const char          *local_pemfile;
 
     /** certificate chain */
-    char                *local_cachain;
+    const char          *local_cachain;
 
     /** verify-mode  */
     int                 local_verify_mode;
@@ -139,7 +139,7 @@ struct s2s_st {
     int                 compression;
 
     /** srvs to lookup */
-    char                **lookup_srv;
+    const char          **lookup_srv;
     int                 lookup_nsrv;
     
     /** if we resolve AAAA records */
@@ -170,7 +170,7 @@ struct s2s_st {
     /** Apple security options */
 	int					require_tls;
 	int					enable_whitelist;
-	char                **whitelist_domains;
+	/*const*/ char      **whitelist_domains; // TODO clarify if need to be const
 	int					n_whitelist_domains;
 
     /** list of sx_t on the way out */
@@ -238,8 +238,8 @@ typedef enum {
 struct conn_st {
     s2s_t               s2s;
 
-    char                *key;
-    char                *dkey;
+    const char          *key;
+    const char          *dkey;
 
     sx_t                s;
     mio_fd_t            fd;
@@ -278,7 +278,7 @@ struct dnsquery_st {
     s2s_t               s2s;
 
     /** domain name */
-    char                *name;
+    const char          *name;
 
     /** srv lookup index */
     int                 srv_i;
@@ -287,7 +287,7 @@ struct dnsquery_st {
     xht                 hosts;
 
     /** current host lookup name */
-    char                *cur_host;
+    const char          *cur_host;
 
     /** current host lookup port */
     int                 cur_port;
@@ -332,7 +332,7 @@ struct dnscache_st {
 /** dns resolution results */
 struct dnsres_st {
     /** ip/port */
-    char                *key;
+    const char          *key;
 
     /** host priority */
     int                 prio;
@@ -348,24 +348,24 @@ extern sig_atomic_t s2s_lost_router;
 
 int             s2s_router_mio_callback(mio_t m, mio_action_t a, mio_fd_t fd, void *data, void *arg);
 int             s2s_router_sx_callback(sx_t s, sx_event_t e, void *data, void *arg);
-int             s2s_domain_in_whitelist(s2s_t s2s, char *in_domain);
+int             s2s_domain_in_whitelist(s2s_t s2s, const char *in_domain);
 
-char            *s2s_route_key(pool_t p, char *local, char *remote);
-int             s2s_route_key_match(char *local, char *remote, char *rkey, int rkeylen);
-char            *s2s_db_key(pool_t p, char *secret, char *remote, char *id);
-char            *dns_make_ipport(char *host, int port);
+char            *s2s_route_key(pool_t p, const char *local, const char *remote);
+int             s2s_route_key_match(char *local, const char *remote, const char *rkey, int rkeylen);
+char            *s2s_db_key(pool_t p, const char *secret, const char *remote, const char *id);
+char            *dns_make_ipport(const char* host, int port);
 
 int             out_packet(s2s_t s2s, pkt_t pkt);
-int             out_route(s2s_t s2s, char *route, int routelen, conn_t *out, int allow_bad);
-int             dns_select(s2s_t s2s, char *ip, int *port, time_t now, dnscache_t dns, int allow_bad);
+int             out_route(s2s_t s2s, const char *route, int routelen, conn_t *out, int allow_bad);
+int             dns_select(s2s_t s2s, char* ip, int* port, time_t now, dnscache_t dns, int allow_bad);
 void            dns_resolve_domain(s2s_t s2s, dnscache_t dns);
-void            out_resolve(s2s_t s2s, char *domain, xht results, time_t expiry);
+void            out_resolve(s2s_t s2s, const char *domain, xht results, time_t expiry);
 void            out_dialback(s2s_t s2s, pkt_t pkt);
 int             out_bounce_domain_queues(s2s_t s2s, const char *domain, int err);
-int             out_bounce_route_queue(s2s_t s2s, char *rkey, int rkeylen, int err);
+int             out_bounce_route_queue(s2s_t s2s, const char *rkey, int rkeylen, int err);
 int             out_bounce_conn_queues(conn_t out, int err);
 void            out_flush_domain_queues(s2s_t s2s, const char *domain);
-void            out_flush_route_queue(s2s_t s2s, char *rkey, int rkeylen);
+void            out_flush_route_queue(s2s_t s2s, const char *rkey, int rkeylen);
 
 int             in_mio_callback(mio_t m, mio_action_t a, mio_fd_t fd, void *data, void *arg);
 

--- a/s2s/util.c
+++ b/s2s/util.c
@@ -24,7 +24,7 @@
 #include "s2s.h"
 
 /** generate a local/remote route key */
-char *s2s_route_key(pool_t p, char *local, char *remote) {
+char *s2s_route_key(pool_t p, const char *local, const char *remote) {
     char *key;
 
     if(local == NULL) local = "";
@@ -41,7 +41,7 @@ char *s2s_route_key(pool_t p, char *local, char *remote) {
 }
 
 /** match route key - used for searching route hash */
-int s2s_route_key_match(char *local, char *remote, char *rkey, int rkeylen) {
+int s2s_route_key_match(char *local, const char *remote, const char *rkey, int rkeylen) {
     char *klocal, *kremote;
     int ret;
 
@@ -58,7 +58,7 @@ int s2s_route_key_match(char *local, char *remote, char *rkey, int rkeylen) {
 }
 
 /** generate a dialback key */
-char *s2s_db_key(pool_t p, char *secret, char *remote, char *id) {
+char *s2s_db_key(pool_t p, const char *secret, const char *remote, const char *id) {
     char hash[41], buf[1024];
 
     _sx_debug(ZONE, "generating dialback key, secret %s, remote %s, id %s", secret, remote, id);

--- a/sm/aci.c
+++ b/sm/aci.c
@@ -83,7 +83,7 @@ xht aci_load(sm_t sm)
 }
 
 /** see if a jid is in an acl */
-int aci_check(xht acls, char *type, jid_t jid)
+int aci_check(xht acls, const char *type, jid_t jid)
 {
     jid_t list, dup;
 

--- a/sm/feature.c
+++ b/sm/feature.c
@@ -34,7 +34,7 @@
  */
 
 /** register a feature */
-void feature_register(sm_t sm, char *feature)
+void feature_register(sm_t sm, const char *feature)
 {
     log_debug(ZONE, "registering feature %s", feature);
 
@@ -42,7 +42,7 @@ void feature_register(sm_t sm, char *feature)
 }
 
 /** unregister feature */
-void feature_unregister(sm_t sm, char *feature)
+void feature_unregister(sm_t sm, const char *feature)
 {
     int refcount = (int) (long) xhash_get(sm->features, feature);
 

--- a/sm/main.c
+++ b/sm/main.c
@@ -73,7 +73,7 @@ static void _sm_signal_usr2(int signum)
 
 /** store the process id */
 static void _sm_pidfile(sm_t sm) {
-    char *pidfile;
+    const char *pidfile;
     FILE *f;
     pid_t pid;
 

--- a/sm/mm.c
+++ b/sm/mm.c
@@ -47,7 +47,8 @@
 mm_t mm_new(sm_t sm) {
     mm_t mm;
     int celem, melem, attr, *nlist = NULL;
-    char id[13], name[32], mod_fullpath[PATH_MAX], arg[1024], *modules_path;
+    char id[13], name[32], mod_fullpath[PATH_MAX], arg[1024];
+    const char *modules_path;
     mod_chain_t chain = (mod_chain_t) NULL;
     mod_instance_t **list = NULL, mi;
     module_t mod;
@@ -241,7 +242,7 @@ mm_t mm_new(sm_t sm) {
                           FreeLibrary((HMODULE) mod->handle);
                     #endif
 
-                    free(mod->name);
+                    free((void*)mod->name);
                     free(mod);
 
                     mm->nindex--;
@@ -283,7 +284,7 @@ static void _mm_reaper(const char *module, int modulelen, void *val, void *arg) 
             FreeLibrary((HMODULE) mod->handle);
     #endif
 
-    free(mod->name);
+    free((void*)mod->name);
     free(mod);
 }
 
@@ -354,7 +355,7 @@ void mm_free(mm_t mm) {
         for(j = 0; j < *nlist; j++) {
             mi = (*list)[j];
             if(mi->arg != NULL)
-                free(mi->arg);
+                free((void*)mi->arg);
             free(mi);
         }
     }

--- a/sm/mod_active.c
+++ b/sm/mod_active.c
@@ -67,7 +67,7 @@ static void _active_user_delete(mod_instance_t mi, jid_t jid) {
     storage_delete(mi->sm->st, "active", jid_user(jid), NULL);
 }
 
-DLLEXPORT int module_init(mod_instance_t mi, char *arg) {
+DLLEXPORT int module_init(mod_instance_t mi, const char *arg) {
     module_t mod = mi->mod;
 
     if(mod->init) return 0;

--- a/sm/mod_amp.c
+++ b/sm/mod_amp.c
@@ -374,10 +374,10 @@ static void _amp_free(module_t mod) {
     free(mod->private);
 }
 
-DLLEXPORT int module_init(mod_instance_t mi, char *arg) {
+DLLEXPORT int module_init(mod_instance_t mi, const char *arg) {
     module_t mod = mi->mod;
     mod_amp_config_t config;
-    char* option;
+    const char* option;
 
     if (mod->init) return 0;
     

--- a/sm/mod_announce.c
+++ b/sm/mod_announce.c
@@ -322,7 +322,7 @@ static void _announce_free(module_t mod) {
     free(data);
 }
 
-DLLEXPORT int module_init(mod_instance_t mi, char *arg) {
+DLLEXPORT int module_init(mod_instance_t mi, const char *arg) {
     module_t mod = mi->mod;
     moddata_t data;
 

--- a/sm/mod_deliver.c
+++ b/sm/mod_deliver.c
@@ -93,7 +93,7 @@ static mod_ret_t _deliver_pkt_user(mod_instance_t mi, user_t user, pkt_t pkt)
     return mod_PASS;
 }
 
-DLLEXPORT int module_init(mod_instance_t mi, char *arg) {
+DLLEXPORT int module_init(mod_instance_t mi, const char *arg) {
     module_t mod = mi->mod;
 
     if(mod->init) return 0;

--- a/sm/mod_disco.c
+++ b/sm/mod_disco.c
@@ -46,9 +46,9 @@ struct service_st {
 typedef struct disco_st *disco_t;
 struct disco_st {
     /** identity */
-    char        *category;
-    char        *type;
-    char        *name;
+    const char  *category;
+    const char  *type;
+    const char  *name;
 
     /** compatibility */
     int         agents;
@@ -605,7 +605,7 @@ static void _disco_free(module_t mod) {
     free(d);
 }
 
-DLLEXPORT int module_init(mod_instance_t mi, char *arg)
+DLLEXPORT int module_init(mod_instance_t mi, const char *arg)
 {
     module_t mod = mi->mod;
     disco_t d;

--- a/sm/mod_echo.c
+++ b/sm/mod_echo.c
@@ -55,7 +55,7 @@ static mod_ret_t _echo_pkt_sm(mod_instance_t mi, pkt_t pkt)
     return mod_HANDLED;
 }
 
-DLLEXPORT int module_init(mod_instance_t mi, char *arg) {
+DLLEXPORT int module_init(mod_instance_t mi, const char *arg) {
     module_t mod = mi->mod;
 
     if(mod->init) return 0;

--- a/sm/mod_help.c
+++ b/sm/mod_help.c
@@ -95,7 +95,7 @@ static mod_ret_t _help_pkt_sm(mod_instance_t mi, pkt_t pkt)
         if (jid_compare_full(pkt->from, jid) == 0) {
             /* make a copy of the nad so it can be dumped to a string */
             nad_t copy = nad_copy(pkt->nad);
-            char * xml;
+            const char * xml;
             int len;
             if (!copy) {
                 log_write(mod->mm->sm->log, LOG_ERR, "%s:%d help admin %s is messaging sm for help! packet dropped. (unable to print packet - out of memory?)", ZONE, jid_full(jid));
@@ -168,7 +168,7 @@ static void _help_disco_extend(mod_instance_t mi, pkt_t pkt)
     }
 }
 
-DLLEXPORT int module_init(mod_instance_t mi, char *arg) {
+DLLEXPORT int module_init(mod_instance_t mi, const char *arg) {
     module_t mod = mi->mod;
 
     if(mod->init) return 0;

--- a/sm/mod_iq_last.c
+++ b/sm/mod_iq_last.c
@@ -145,7 +145,7 @@ static void _iq_last_free(module_t mod) {
     feature_unregister(mod->mm->sm, uri_LAST);
 }
 
-DLLEXPORT int module_init(mod_instance_t mi, char *arg) {
+DLLEXPORT int module_init(mod_instance_t mi, const char *arg) {
     module_t mod = mi->mod;
 
     if(mod->init) return 0;

--- a/sm/mod_iq_ping.c
+++ b/sm/mod_iq_ping.c
@@ -63,7 +63,7 @@ static void _iq_ping_free(module_t mod) {
     feature_unregister(mod->mm->sm, urn_PING);
 }
 
-DLLEXPORT int module_init(mod_instance_t mi, char *arg) {
+DLLEXPORT int module_init(mod_instance_t mi, const char *arg) {
     module_t mod = mi->mod;
 
     if(mod->init) return 0;

--- a/sm/mod_iq_private.c
+++ b/sm/mod_iq_private.c
@@ -206,7 +206,7 @@ static void _iq_private_free(module_t mod) {
      feature_unregister(mod->mm->sm, uri_PRIVATE);
 }
 
-DLLEXPORT int module_init(mod_instance_t mi, char *arg) {
+DLLEXPORT int module_init(mod_instance_t mi, const char *arg) {
     module_t mod = mi->mod;
 
     if (mod->init) return 0;

--- a/sm/mod_iq_time.c
+++ b/sm/mod_iq_time.c
@@ -99,7 +99,7 @@ static void _iq_time_free(module_t mod) {
      feature_unregister(mod->mm->sm, uri_TIME);
 }
 
-DLLEXPORT int module_init(mod_instance_t mi, char *arg) {
+DLLEXPORT int module_init(mod_instance_t mi, const char *arg) {
     module_t mod = mi->mod;
 
     if(mod->init) return 0;

--- a/sm/mod_iq_vcard.c
+++ b/sm/mod_iq_vcard.c
@@ -395,7 +395,7 @@ static void _iq_vcard_free(module_t mod) {
     free(mod->private);
 }
 
-DLLEXPORT int module_init(mod_instance_t mi, char *arg) {
+DLLEXPORT int module_init(mod_instance_t mi, const char *arg) {
     module_t mod = mi->mod;
     mod_iq_vcard_t iq_vcard;
 

--- a/sm/mod_iq_version.c
+++ b/sm/mod_iq_version.c
@@ -259,7 +259,7 @@ static void _iq_version_free(module_t mod) {
     free(config);
 }
 
-DLLEXPORT int module_init(mod_instance_t mi, char *arg) {
+DLLEXPORT int module_init(mod_instance_t mi, const char *arg) {
     mod_iq_version_config_t config;
     module_t mod = mi->mod;
 

--- a/sm/mod_offline.c
+++ b/sm/mod_offline.c
@@ -278,9 +278,9 @@ static void _offline_free(module_t mod) {
     free(offline);
 }
 
-DLLEXPORT int module_init(mod_instance_t mi, char *arg) {
+DLLEXPORT int module_init(mod_instance_t mi, const char *arg) {
     module_t mod = mi->mod;
-    char *configval;
+    const char *configval;
     mod_offline_t offline;
 
     if(mod->init) return 0;

--- a/sm/mod_pep.c
+++ b/sm/mod_pep.c
@@ -75,7 +75,7 @@ static mod_ret_t _pep_out_sess(mod_instance_t mi, sess_t sess, pkt_t pkt) {
     return mod_PASS;
 }
 
-DLLEXPORT int module_init(mod_instance_t mi, char *arg) {
+DLLEXPORT int module_init(mod_instance_t mi, const char *arg) {
     module_t mod = mi->mod;
 
     if(mod->init) return 0;

--- a/sm/mod_presence.c
+++ b/sm/mod_presence.c
@@ -180,7 +180,7 @@ static void _presence_free(module_t mod) {
     feature_unregister(mod->mm->sm, "presence");
 }
 
-DLLEXPORT int module_init(mod_instance_t mi, char *arg) {
+DLLEXPORT int module_init(mod_instance_t mi, const char *arg) {
     module_t mod = mi->mod;
 
     if(mod->init) return 0;

--- a/sm/mod_privacy.c
+++ b/sm/mod_privacy.c
@@ -335,7 +335,7 @@ static int _privacy_action(user_t user, zebra_list_t zlist, jid_t jid, pkt_type_
                 break;
 
             case zebra_JID:
-                sprintf(domres, "%s/%s", jid->domain, jid->resource);
+                snprintf(domres, sizeof(domres) / sizeof(domres[0]), "%s/%s", jid->domain, jid->resource);
  
                 /* jid check - match node@dom/res, then node@dom, then dom/resource, then dom */
                 if(jid_compare_full(scan->jid, jid) == 0 ||
@@ -1320,7 +1320,7 @@ static void _privacy_free(module_t mod) {
      feature_unregister(mod->mm->sm, uri_PRIVACY);
 }
 
-DLLEXPORT int module_init(mod_instance_t mi, char *arg) {
+DLLEXPORT int module_init(mod_instance_t mi, const char *arg) {
     module_t mod = mi->mod;
 
     if (mod->init) return 0;

--- a/sm/mod_roster.c
+++ b/sm/mod_roster.c
@@ -47,10 +47,10 @@ static void _roster_freeuser_walker(const char *key, int keylen, void *val, void
     jid_free(item->jid);
     
     if(item->name != NULL)
-        free(item->name);
+        free((void*)item->name);
 
     for(i = 0; i < item->ngroups; i++)
-        free(item->groups[i]);
+        free((void*)item->groups[i]);
     free(item->groups);
 
     free(item);
@@ -417,14 +417,14 @@ static void _roster_set_item(pkt_t pkt, int elem, sess_t sess, mod_instance_t mi
     {
         /* free the old name */
         if(item->name != NULL) {
-            free(item->name);
+            free((void*)item->name);
             item->name = NULL;
         }
 
         if (NAD_AVAL_L(pkt->nad, attr) > 0)
         {
-            item->name = (char *) malloc(sizeof(char) * (NAD_AVAL_L(pkt->nad, attr) + 1));
-            sprintf(item->name, "%.*s", NAD_AVAL_L(pkt->nad, attr), NAD_AVAL(pkt->nad, attr));
+            item->name = (const char *) malloc(sizeof(char) * (NAD_AVAL_L(pkt->nad, attr) + 1));
+            sprintf((char *)item->name, "%.*s", NAD_AVAL_L(pkt->nad, attr), NAD_AVAL(pkt->nad, attr));
         }
     }
 
@@ -432,7 +432,7 @@ static void _roster_set_item(pkt_t pkt, int elem, sess_t sess, mod_instance_t mi
     if(item->groups != NULL)
     {
         for(i = 0; i < item->ngroups; i++)
-            free(item->groups[i]);
+            free((void*)item->groups[i]);
         free(item->groups);
         item->ngroups = 0;
         item->groups = NULL;
@@ -446,10 +446,10 @@ static void _roster_set_item(pkt_t pkt, int elem, sess_t sess, mod_instance_t mi
         if(NAD_CDATA_L(pkt->nad, elem) >= 0)
         {
             /* make room and shove it in */
-            item->groups = (char **) realloc(item->groups, sizeof(char *) * (item->ngroups + 1));
+            item->groups = (const char **) realloc(item->groups, sizeof(char *) * (item->ngroups + 1));
 
-            item->groups[item->ngroups] = (char *) malloc(sizeof(char) * (NAD_CDATA_L(pkt->nad, elem) + 1));
-            sprintf(item->groups[item->ngroups], "%.*s", NAD_CDATA_L(pkt->nad, elem), NAD_CDATA(pkt->nad, elem));
+            item->groups[item->ngroups] = (const char *) malloc(sizeof(char) * (NAD_CDATA_L(pkt->nad, elem) + 1));
+            sprintf((char *)(item->groups[item->ngroups]), "%.*s", NAD_CDATA_L(pkt->nad, elem), NAD_CDATA(pkt->nad, elem));
 
             item->ngroups++;
         }
@@ -828,7 +828,7 @@ static void _roster_free(module_t mod)
     free(mroster);
 }
 
-DLLEXPORT int module_init(mod_instance_t mi, char *arg) {
+DLLEXPORT int module_init(mod_instance_t mi, const char *arg) {
     module_t mod = mi->mod;
     mod_roster_t mroster;
 

--- a/sm/mod_roster_publish.c
+++ b/sm/mod_roster_publish.c
@@ -42,8 +42,8 @@ struct _roster_publish_group_cache_st {
 
 typedef struct _roster_publish_st {
     int publish, forcegroups, fixsubs, overridenames, mappedgroups, fixexist;
-    char *fetchdomain, *fetchuser, *fetchfixed, *dbtable;
-    char *groupprefix, *groupsuffix, *removedomain;
+    const char *fetchdomain, *fetchuser, *fetchfixed, *dbtable;
+    const char *groupprefix, *groupsuffix, *removedomain;
     int groupprefixlen, groupsuffixlen;
     time_t active_cache_ttl;
     time_t group_cache_ttl;
@@ -75,7 +75,7 @@ static void _roster_publish_free_group_cache_walker(const char *key, int keylen,
  * get group's descriptive name by it's text id
  * returned value needs to be freed by caller
  */
-static char *_roster_publish_get_group_name(sm_t sm, roster_publish_t rp, char *groupid)
+static const char *_roster_publish_get_group_name(sm_t sm, roster_publish_t rp, const char *groupid)
 {
     os_t os;
     os_object_t o;
@@ -144,10 +144,10 @@ static void _roster_publish_free_walker(xht roster, const char *key, void *val, 
     jid_free(item->jid);
     
     if(item->name != NULL)
-        free(item->name);
+        free((void*)item->name);
 
     for(i = 0; i < item->ngroups; i++)
-        free(item->groups[i]);
+        free((void*)item->groups[i]);
     free(item->groups);
 
     free(item);
@@ -205,7 +205,9 @@ static int _roster_publish_user_load(mod_instance_t mi, user_t user) {
     roster_publish_t roster_publish = (roster_publish_t) mi->mod->private;
     os_t os, os_active;
     os_object_t o, o_active;
-    char *str, *group, filter[4096];
+    char *str;
+    const char *group;
+    char filter[4096];
     const char *fetchkey;
     int i,j,gpos,found,delete,checksm,tmp_to,tmp_from,tmp_do_change;
     item_t item;
@@ -471,7 +473,7 @@ static int _roster_publish_user_load(mod_instance_t mi, user_t user) {
                                         }
                                         /* remove group from roster item */
                                         if( delete ) {
-                                            free(item->groups[i]);
+                                            free((void*)item->groups[i]);
                                             for(j = i; j < item->ngroups-1; j++) {
                                                 item->groups[j]=item->groups[j+1];
                                             }
@@ -489,7 +491,7 @@ static int _roster_publish_user_load(mod_instance_t mi, user_t user) {
                                     xhash_put(user->roster, jid_full(item->jid), (void *) item);
                                     _roster_publish_save_item(user,item);
                                 } else {
-                                    free(group);
+                                    free((void*)group);
                                 }
                             } /* else if( roster_publish->forcegroups ) */
                         } /* end of if if( item == NULL ) */
@@ -519,7 +521,7 @@ static void _roster_publish_free(module_t mod) {
     free(roster_publish);
 }
 
-DLLEXPORT int module_init(mod_instance_t mi, char *arg) {
+DLLEXPORT int module_init(mod_instance_t mi, const char *arg) {
     module_t mod = mi->mod;
     roster_publish_t roster_publish;
 

--- a/sm/mod_session.c
+++ b/sm/mod_session.c
@@ -343,7 +343,7 @@ static mod_ret_t _session_pkt_router(mod_instance_t mi, pkt_t pkt) {
     return mod_PASS;
 }
 
-DLLEXPORT int module_init(mod_instance_t mi, char *arg) {
+DLLEXPORT int module_init(mod_instance_t mi, const char *arg) {
     if(mi->mod->init) return 0;
 
     mi->mod->in_router = _session_in_router;

--- a/sm/mod_status.c
+++ b/sm/mod_status.c
@@ -30,8 +30,8 @@
 #include "sm.h"
 
 typedef struct _status_st {
-    sm_t    sm;
-    char    *resource;
+    sm_t       sm;
+    const char *resource;
 } *status_t;
 
 static void _status_os_replace(storage_t st, const unsigned char *jid, char *status, char *show, time_t *lastlogin, time_t *lastlogout, nad_t nad) {
@@ -226,7 +226,7 @@ static void _status_free(module_t mod) {
     free(mod->private);
 }
 
-DLLEXPORT int module_init(mod_instance_t mi, char *arg) {
+DLLEXPORT int module_init(mod_instance_t mi, const char *arg) {
     module_t mod = mi->mod;
 
     status_t tr;

--- a/sm/mod_template_roster.c
+++ b/sm/mod_template_roster.c
@@ -30,10 +30,10 @@
 /* user template - roster */
 
 typedef struct _template_roster_st {
-    sm_t    sm;
-    char    *filename;
-    time_t  mtime;
-    xht     items;
+    sm_t       sm;
+    const char *filename;
+    time_t     mtime;
+    xht        items;
 } *template_roster_t;
 
 /* union for xhash_iter_get to comply with strict-alias rules for gcc3 */
@@ -140,7 +140,7 @@ static int _template_roster_reload(template_roster_t tr) {
                 continue;
             }
 
-            item->groups = (char **) realloc(item->groups, sizeof(char *) * (item->ngroups + 1));
+            item->groups = (const char **) realloc(item->groups, sizeof(char *) * (item->ngroups + 1));
             item->groups[item->ngroups] = pstrdupx(xhash_pool(tr->items), NAD_CDATA(nad, egroup), NAD_CDATA_L(nad, egroup));
             item->ngroups++;
 
@@ -242,9 +242,9 @@ static void _template_roster_free(module_t mod) {
     free(tr);
 }
 
-DLLEXPORT int module_init(mod_instance_t mi, char *arg) {
+DLLEXPORT int module_init(mod_instance_t mi, const char *arg) {
     module_t mod = mi->mod;
-    char *filename;
+    const char *filename;
     template_roster_t tr;
 
     if(mod->init) return 0;

--- a/sm/mod_vacation.c
+++ b/sm/mod_vacation.c
@@ -238,7 +238,7 @@ static void _vacation_free(module_t mod) {
     feature_unregister(mod->mm->sm, uri_VACATION);
 }
 
-DLLEXPORT int module_init(mod_instance_t mi, char *arg) {
+DLLEXPORT int module_init(mod_instance_t mi, const char *arg) {
     module_t mod = mi->mod;
 
     if(mod->init) return 0;

--- a/sm/mod_validate.c
+++ b/sm/mod_validate.c
@@ -43,7 +43,7 @@ static mod_ret_t _validate_in_router(mod_instance_t mi, pkt_t pkt)
     return _validate_in_sess(mi, NULL, pkt);
 }
 
-DLLEXPORT int module_init(mod_instance_t mi, char *arg) {
+DLLEXPORT int module_init(mod_instance_t mi, const char *arg) {
     module_t mod = mi->mod;
 
     if(mod->init) return 0;

--- a/sm/sess.c
+++ b/sm/sess.c
@@ -203,7 +203,7 @@ sess_t sess_start(sm_t sm, jid_t jid) {
 }
 
 /** match a session by resource */
-sess_t sess_match(user_t user, char *resource) {
+sess_t sess_match(user_t user, const char *resource) {
     sess_t sess;
 
     for(sess = user->sessions; sess != NULL; sess = sess->next) {

--- a/sm/sm.c
+++ b/sm/sm.c
@@ -277,7 +277,7 @@ int sm_mio_callback(mio_t m, mio_action_t a, mio_fd_t fd, void *data, void *arg)
 }
 
 /** send a new action route */
-void sm_c2s_action(sess_t dest, char *action, char *target) {
+void sm_c2s_action(sess_t dest, const char *action, const char *target) {
     nad_t nad;
     int rns, sns;
 
@@ -310,7 +310,7 @@ void sm_c2s_action(sess_t dest, char *action, char *target) {
 }
 
 /** this is gratuitous, but apache gets one, so why not? */
-void sm_signature(sm_t sm, char *str) {
+void sm_signature(sm_t sm, const char *str) {
     if (sm->siglen == 0) {
         snprintf(&sm->signature[sm->siglen], 2048 - sm->siglen, "%s", str);
         sm->siglen += strlen(str);
@@ -321,7 +321,7 @@ void sm_signature(sm_t sm, char *str) {
 }
 
 /** register a new global ns */
-int sm_register_ns(sm_t sm, char *uri) {
+int sm_register_ns(sm_t sm, const char *uri) {
     int ns_idx;
 
     ns_idx = (int) (long) xhash_get(sm->xmlns, uri);
@@ -335,7 +335,7 @@ int sm_register_ns(sm_t sm, char *uri) {
 }
 
 /** unregister a global ns */
-void sm_unregister_ns(sm_t sm, char *uri) {
+void sm_unregister_ns(sm_t sm, const char *uri) {
     int refcount = (int) (long) xhash_get(sm->xmlns_refcount, uri);
     if (refcount == 1) {
         xhash_zap(sm->xmlns, uri);
@@ -346,7 +346,7 @@ void sm_unregister_ns(sm_t sm, char *uri) {
 }
 
 /** get a globally registered ns */
-int sm_get_ns(sm_t sm, char *uri) {
+int sm_get_ns(sm_t sm, const char *uri) {
     return (int) (long) xhash_get(sm->xmlns, uri);
 }
 

--- a/sm/sm.h
+++ b/sm/sm.h
@@ -150,9 +150,9 @@ typedef struct pkt_st {
 typedef struct item_st {
     jid_t               jid;        /**< id of this item */
 
-    char                *name;      /**< display name */
+    const char          *name;      /**< display name */
 
-    char                **groups;   /**< groups this item is in */
+    const char          **groups;   /**< groups this item is in */
 
     int                 ngroups;    /**< number of groups in groups array */
 
@@ -165,13 +165,13 @@ typedef struct item_st {
 
 /** session manager global context */
 struct sm_st {
-    char                *id;                /**< component id */
+    const char          *id;                /**< component id */
 
-    char                *router_ip;         /**< ip to connect to the router at */
+    const char          *router_ip;         /**< ip to connect to the router at */
     int                 router_port;        /**< port to connect to the router at */
-    char                *router_user;       /**< username to authenticate to the router as */
-    char                *router_pass;       /**< password to authenticate to the router with */
-    char                *router_pemfile;    /**< name of file containing a SSL certificate &
+    const char          *router_user;       /**< username to authenticate to the router as */
+    const char          *router_pass;       /**< password to authenticate to the router with */
+    const char          *router_pemfile;    /**< name of file containing a SSL certificate &
                                                  key for channel to the router */
 
     mio_t               mio;                /**< mio context */
@@ -197,8 +197,8 @@ struct sm_st {
     log_t               log;                /**< log context */
 
     log_type_t          log_type;           /**< log type */
-    char                *log_facility;      /**< syslog facility (local0 - local7) */
-    char                *log_ident;         /**< log identifier */
+    const char          *log_facility;      /**< syslog facility (local0 - local7) */
+    const char          *log_ident;         /**< log identifier */
 
     int                 retry_init;         /**< number of times to try connecting to the router at startup */
     int                 retry_lost;         /**< number of times to try reconnecting to the router if the connection drops */
@@ -277,18 +277,18 @@ extern sig_atomic_t sm_lost_router;
 
 /* functions */
 SM_API xht             aci_load(sm_t sm);
-SM_API int             aci_check(xht acls, char *type, jid_t jid);
+SM_API int             aci_check(xht acls, const char *type, jid_t jid);
 SM_API void            aci_unload(xht acls);
 
 SM_API int             sm_sx_callback(sx_t s, sx_event_t e, void *data, void *arg);
 SM_API int             sm_mio_callback(mio_t m, mio_action_t a, mio_fd_t fd, void *data, void *arg);
 SM_API void            sm_timestamp(time_t t, char timestamp[18]);
-SM_API void            sm_c2s_action(sess_t dest, char *action, char *target);
-SM_API void            sm_signature(sm_t sm, char *str);
+SM_API void            sm_c2s_action(sess_t dest, const char *action, const char *target);
+SM_API void            sm_signature(sm_t sm, const char *str);
 
-SM_API int             sm_register_ns(sm_t sm, char *uri);
-SM_API void            sm_unregister_ns(sm_t sm, char *uri);
-SM_API int             sm_get_ns(sm_t sm, char *uri);
+SM_API int             sm_register_ns(sm_t sm, const char *uri);
+SM_API void            sm_unregister_ns(sm_t sm, const char *uri);
+SM_API int             sm_get_ns(sm_t sm, const char *uri);
 
 SM_API int             sm_storage_rate_limit(sm_t sm, const char *owner);
 
@@ -318,15 +318,15 @@ SM_API void            pres_probe(user_t user);
 SM_API void            sess_route(sess_t sess, pkt_t pkt);
 SM_API sess_t          sess_start(sm_t sm, jid_t jid);
 SM_API void            sess_end(sess_t sess);
-SM_API sess_t          sess_match(user_t user, char *resource);
+SM_API sess_t          sess_match(user_t user, const char *resource);
 
 SM_API user_t          user_load(sm_t sm, jid_t jid);
 SM_API void            user_free(user_t user);
 SM_API int             user_create(sm_t sm, jid_t jid);
 SM_API void            user_delete(sm_t sm, jid_t jid);
 
-SM_API void            feature_register(sm_t sm, char *feature);
-SM_API void            feature_unregister(sm_t sm, char *feature);
+SM_API void            feature_register(sm_t sm, const char *feature);
+SM_API void            feature_unregister(sm_t sm, const char *feature);
 
 
 /* driver module manager */
@@ -400,7 +400,7 @@ struct mm_st {
 struct module_st {
     mm_t                mm;         /**< module manager */
 
-    char                *name;      /**< name of module */
+    const char          *name;      /**< name of module */
 
     int                 index;      /**< module index. this is the index into user->module_data and
                                          sess->module_data where the module can store its own
@@ -449,7 +449,7 @@ struct mod_instance_st {
 
     mod_chain_t         chain;      /**< chain this instance is in */
 
-    char                *arg;       /**< option arg that this instance was started with */
+    const char          *arg;       /**< option arg that this instance was started with */
 };
 
 /** allocate a module manager instance, and loads the modules */

--- a/storage/authreg_anon.c
+++ b/storage/authreg_anon.c
@@ -25,13 +25,13 @@
 
 #include "c2s.h"
 
-static int _ar_anon_user_exists(authreg_t ar, char *username, char *realm)
+static int _ar_anon_user_exists(authreg_t ar, const char *username, const char *realm)
 {
     /* always exists */
     return 1;
 }
 
-static int _ar_anon_check_password(authreg_t ar, char *username, char *realm, char password[257])
+static int _ar_anon_check_password(authreg_t ar, const char *username, const char *realm, char password[257])
 {
     /* always correct */
     return 0;

--- a/storage/authreg_db.c
+++ b/storage/authreg_db.c
@@ -46,7 +46,7 @@ typedef struct moddata_st
 {
     DB_ENV  *env;
 
-    char    *path;
+    const char *path;
     int     sync;
 
     xht     realms;
@@ -54,7 +54,7 @@ typedef struct moddata_st
 } *moddata_t;
 
 /** open/create the database for this realm */
-static DB *_ar_db_get_realm_db(authreg_t ar, char *realm)
+static DB *_ar_db_get_realm_db(authreg_t ar, const char *realm)
 {
     moddata_t data = (moddata_t) ar->private;
     DB *db;
@@ -95,7 +95,7 @@ static DB *_ar_db_get_realm_db(authreg_t ar, char *realm)
 }
 
 /** pull a user out of the db */
-static creds_t _ar_db_fetch_user(authreg_t ar, char *username, char *realm)
+static creds_t _ar_db_fetch_user(authreg_t ar, const char *username, const char *realm)
 {
     DB *db;
     DBT key, val;
@@ -111,7 +111,7 @@ static creds_t _ar_db_fetch_user(authreg_t ar, char *username, char *realm)
     memset(&key, 0, sizeof(DBT));
     memset(&val, 0, sizeof(DBT));
     
-    key.data = username;
+    key.data = (void*)username;
     key.size = strlen(username);
 
     err = db->get(db, NULL, &key, &val, 0);
@@ -166,12 +166,12 @@ static int _ar_db_store_user(authreg_t ar, creds_t creds)
     return 0;
 }
 
-static int _ar_db_user_exists(authreg_t ar, char *username, char *realm)
+static int _ar_db_user_exists(authreg_t ar, const char *username, const char *realm)
 {
     return (int) (long) _ar_db_fetch_user(ar, username, realm);
 }
 
-static int _ar_db_get_password(authreg_t ar, char *username, char *realm, char password[257])
+static int _ar_db_get_password(authreg_t ar, const char *username, const char *realm, char password[257])
 {
     creds_t creds;
 
@@ -183,7 +183,7 @@ static int _ar_db_get_password(authreg_t ar, char *username, char *realm, char p
     return 0;
 }
 
-static int _ar_db_set_password(authreg_t ar, char *username, char *realm, char password[257])
+static int _ar_db_set_password(authreg_t ar, const char *username, const char *realm, char password[257])
 {
     creds_t creds;
 
@@ -198,7 +198,7 @@ static int _ar_db_set_password(authreg_t ar, char *username, char *realm, char p
     return 0;
 }
 
-static int _ar_db_create_user(authreg_t ar, char *username, char *realm)
+static int _ar_db_create_user(authreg_t ar, const char *username, const char *realm)
 {
     creds_t creds;
     int ret;
@@ -217,7 +217,7 @@ static int _ar_db_create_user(authreg_t ar, char *username, char *realm)
     return ret;
 }
 
-static int _ar_db_delete_user(authreg_t ar, char *username, char *realm)
+static int _ar_db_delete_user(authreg_t ar, const char *username, const char *realm)
 {
     DB *db;
     DBT key;
@@ -232,7 +232,7 @@ static int _ar_db_delete_user(authreg_t ar, char *username, char *realm)
 
     memset(&key, 0, sizeof(DBT));
 
-    key.data = username;
+    key.data = (void*)username;
     key.size = strlen(username);
 
     err = db->del(db, NULL, &key, 0);
@@ -285,7 +285,7 @@ static void _ar_db_panic(DB_ENV *env, int errval)
 /** start me up */
 int ar_init(authreg_t ar)
 {
-    char *path;
+    const char *path;
     int err;
     DB_ENV *env;
     moddata_t data;

--- a/storage/authreg_ntlogon.c
+++ b/storage/authreg_ntlogon.c
@@ -27,13 +27,13 @@ typedef BOOL (CALLBACK FNLOGONUSERA)(LPTSTR, LPTSTR, LPTSTR, DWORD, DWORD, PHAND
 FNLOGONUSERA *_LogonUserA = NULL;
 HANDLE hModule = NULL;
 
-static int _ar_ntlogon_user_exists(authreg_t ar, char *username, char *realm)
+static int _ar_ntlogon_user_exists(authreg_t ar, const char *username, const char *realm)
 {
 	/* we can't check if a user exists, so we just assume we have them all the time */
 	return 1;
 }
 
-static int _ar_ntlogon_check_password(authreg_t ar, char *username, char *realm, char password[257])
+static int _ar_ntlogon_check_password(authreg_t ar, const char *username, const char *realm, char password[257])
 {
 	HANDLE hToken = NULL;
 	if(!_LogonUserA) return 1;

--- a/storage/authreg_oracle.c
+++ b/storage/authreg_oracle.c
@@ -66,7 +66,7 @@ static int _st_oracle_realloc(void **oblocks, int len)
 
 #define ORACLE_SAFE(blocks, size, len) if((size) > len){ len = _st_oracle_realloc((void**)&(blocks),(size)); }
 
-int checkOCIError( authreg_t ar, char *szDoing, OCIError *m_ociError, sword nStatus )
+int checkOCIError( authreg_t ar, const char *szDoing, OCIError *m_ociError, sword nStatus )
 {
     text txtErrorBuffer[512];
     ub4 nErrorCode;
@@ -163,7 +163,7 @@ static int _ar_oracle_get_user_tuple( authreg_t ar, char* username, char* realm 
     else return 0;
 }
 
-static int _ar_oracle_user_exists(authreg_t ar, char *username, char *realm)
+static int _ar_oracle_user_exists(authreg_t ar, const char *username, const char *realm)
 {
     if( _ar_oracle_get_user_tuple(ar, username, realm ) > 0 )
     {
@@ -173,7 +173,7 @@ static int _ar_oracle_user_exists(authreg_t ar, char *username, char *realm)
     return 0;
 }
 
-static int _ar_oracle_create_user( authreg_t ar, char *username, char *realm )
+static int _ar_oracle_create_user( authreg_t ar, const char *username, const char *realm )
 {
     Oracle_context_t _ctx = (Oracle_context_t)ar->private;
     char* _sqlbuf = NULL;
@@ -244,7 +244,7 @@ int _ar_oracle_get_authreg_user( authreg_t ar )
 }
 
 
-static int _ar_oracle_get_password( authreg_t ar, char *username, char *realm, char password[PWSIZE] )
+static int _ar_oracle_get_password( authreg_t ar, const char *username, const char *realm, char password[PWSIZE] )
 {
     Oracle_context_t _ctx = (Oracle_context_t)ar->private;
     char* _sqlbuf = NULL;
@@ -289,7 +289,7 @@ static int _ar_oracle_get_password( authreg_t ar, char *username, char *realm, c
     return 0;
 }
 
-static int _ar_oracle_set_password(authreg_t ar, char *username, char *realm, char password[PWSIZE])
+static int _ar_oracle_set_password(authreg_t ar, const char *username, const char *realm, char password[PWSIZE])
 {
     Oracle_context_t _ctx = (Oracle_context_t)ar->private;
     char* _sqlbuf = NULL;
@@ -317,7 +317,7 @@ static int _ar_oracle_set_password(authreg_t ar, char *username, char *realm, ch
     return 0;
 }
 
-static int _ar_oracle_delete_user(authreg_t ar, char *username, char *realm)
+static int _ar_oracle_delete_user(authreg_t ar, const char *username, const char *realm)
 {
     if( _ar_oracle_get_user_tuple(ar, username, realm ) == 0 )return 0;
 
@@ -360,7 +360,7 @@ static void _ar_oracle_free( authreg_t ar )
 }
 
 /** Provide a configuration parameter or default value. */
-static char * _ar_oracle_param( config_t c, char * key, char * def ) {
+static char * _ar_oracle_param( config_t c, const char * key, const char * def ) {
     char * value = config_get_one( c, key, 0 );
     if( value == NULL )
       return def;

--- a/storage/authreg_pam.c
+++ b/storage/authreg_pam.c
@@ -23,7 +23,7 @@
 #include "c2s.h"
 #include <security/pam_appl.h>
 
-static int _ar_pam_user_exists(authreg_t ar, char *username, char *realm) {
+static int _ar_pam_user_exists(authreg_t ar, const char *username, const char *realm) {
     /* we can't check if a user exists, so we just assume we have them all the time */
     return 1;
 }
@@ -56,7 +56,7 @@ static int _ar_pam_delay(int ret, unsigned int usec, void *arg) {
 }
 #endif
 
-static int _ar_pam_check_password(authreg_t ar, char *username, char *realm, char password[257]) {
+static int _ar_pam_check_password(authreg_t ar, const char *username, const char *realm, char password[257]) {
     struct pam_conv conv;
     pam_handle_t *pam;
     int ret, user_len, realm_len;

--- a/storage/authreg_pipe.c
+++ b/storage/authreg_pipe.c
@@ -39,14 +39,14 @@
 
 /** internal structure, holds our data */
 typedef struct moddata_st {
-    char    *exec;
+    const char    *exec;
     
     pid_t   child;
 
     int     in, out;
 } *moddata_t;
 
-static int _ar_pipe_write(authreg_t ar, int fd, char *msgfmt, ...)
+static int _ar_pipe_write(authreg_t ar, int fd, const char *msgfmt, ...)
 {
     va_list args;
     char buf[1024];
@@ -88,7 +88,7 @@ static int _ar_pipe_read(authreg_t ar, int fd, char *buf, int buflen)
     return ret;
 }
 
-static int _ar_pipe_user_exists(authreg_t ar, char *username, char *realm)
+static int _ar_pipe_user_exists(authreg_t ar, const char *username, const char *realm)
 {
     moddata_t data = (moddata_t) ar->private;
     char buf[1024];
@@ -105,7 +105,7 @@ static int _ar_pipe_user_exists(authreg_t ar, char *username, char *realm)
     return 1;
 }
 
-static int _ar_pipe_get_password(authreg_t ar, char *username, char *realm, char password[257])
+static int _ar_pipe_get_password(authreg_t ar, const char *username, const char *realm, char password[257])
 {
     moddata_t data = (moddata_t) ar->private;
     char buf[1024];
@@ -137,7 +137,7 @@ static int _ar_pipe_get_password(authreg_t ar, char *username, char *realm, char
     return 0;
 }
 
-static int _ar_pipe_check_password(authreg_t ar, char *username, char *realm, char password[257])
+static int _ar_pipe_check_password(authreg_t ar, const char *username, const char *realm, char password[257])
 {
     moddata_t data = (moddata_t) ar->private;
     char buf[1024];
@@ -164,7 +164,7 @@ static int _ar_pipe_check_password(authreg_t ar, char *username, char *realm, ch
     return 0;
 }
 
-static int _ar_pipe_set_password(authreg_t ar, char *username, char *realm, char password[257])
+static int _ar_pipe_set_password(authreg_t ar, const char *username, const char *realm, char password[257])
 {
     moddata_t data = (moddata_t) ar->private;
     char buf[1024];
@@ -191,7 +191,7 @@ static int _ar_pipe_set_password(authreg_t ar, char *username, char *realm, char
     return 0;
 }
 
-static int _ar_pipe_create_user(authreg_t ar, char *username, char *realm)
+static int _ar_pipe_create_user(authreg_t ar, const char *username, const char *realm)
 {
     moddata_t data = (moddata_t) ar->private;
     char buf[1024];
@@ -208,7 +208,7 @@ static int _ar_pipe_create_user(authreg_t ar, char *username, char *realm)
     return 0;
 }
 
-static int _ar_pipe_delete_user(authreg_t ar, char *username, char *realm)
+static int _ar_pipe_delete_user(authreg_t ar, const char *username, const char *realm)
 {
     moddata_t data = (moddata_t) ar->private;
     char buf[1024];

--- a/storage/authreg_sqlite.c
+++ b/storage/authreg_sqlite.c
@@ -44,7 +44,7 @@ typedef struct moddata_st {
 } *moddata_t;
 
 static sqlite3_stmt*
-_get_stmt(authreg_t ar, sqlite3 *db, sqlite3_stmt **stmt, char *sql)
+_get_stmt(authreg_t ar, sqlite3 *db, sqlite3_stmt **stmt, const char *sql)
 {
     int res;
     if (*stmt == NULL) {
@@ -61,7 +61,7 @@ _get_stmt(authreg_t ar, sqlite3 *db, sqlite3_stmt **stmt, char *sql)
  * @return 1 if the user exists, 0 if not 
  */
 static int
-_ar_sqlite_user_exists(authreg_t ar, char *username, char *realm)
+_ar_sqlite_user_exists(authreg_t ar, const char *username, const char *realm)
 {
 
     sqlite3_stmt *stmt;
@@ -95,7 +95,7 @@ _ar_sqlite_user_exists(authreg_t ar, char *username, char *realm)
  * @return 0 is password is populated, 1 if not 
  */
 static int
-_ar_sqlite_get_password(authreg_t ar, char *username, char *realm,
+_ar_sqlite_get_password(authreg_t ar, const char *username, const char *realm,
 			char password[257])
 {
 
@@ -128,7 +128,7 @@ _ar_sqlite_get_password(authreg_t ar, char *username, char *realm,
  * @return 0 if the given password matches the password stored in the database, !0 if not
  */
 static int
-_ar_sqlite_check_password(authreg_t ar, char *username, char *realm,
+_ar_sqlite_check_password(authreg_t ar, const char *username, const char *realm,
 			  char password[257])
 {
 
@@ -161,7 +161,7 @@ _ar_sqlite_check_password(authreg_t ar, char *username, char *realm,
  * @return 0 if password is stored, 1 if not
  */
 static int
-_ar_sqlite_set_password(authreg_t ar, char *username, char *realm,
+_ar_sqlite_set_password(authreg_t ar, const char *username, const char *realm,
 			char password[257])
 {
 
@@ -196,7 +196,7 @@ _ar_sqlite_set_password(authreg_t ar, char *username, char *realm,
  * @return 0 if user is created, 1 if not
  */
 static int
-_ar_sqlite_create_user(authreg_t ar, char *username, char *realm)
+_ar_sqlite_create_user(authreg_t ar, const char *username, const char *realm)
 {
     sqlite3_stmt *stmt;
     moddata_t data = data = (moddata_t) ar->private;
@@ -221,14 +221,14 @@ _ar_sqlite_create_user(authreg_t ar, char *username, char *realm)
 	ret = 1;
     }
     sqlite3_reset(stmt);
-    return 0;
+    return ret;
 }
 
 /**
  * @return 0 if user is deleted, 1 if not
  */
 static int
-_ar_sqlite_delete_user(authreg_t ar, char *username, char *realm)
+_ar_sqlite_delete_user(authreg_t ar, const char *username, const char *realm)
 {
     sqlite3_stmt *stmt;
     moddata_t data = (moddata_t) ar->private;
@@ -285,8 +285,8 @@ ar_init(authreg_t ar)
     int ret;
     sqlite3 *db;
     moddata_t data;
-    char *busy_timeout;
-    char *dbname = config_get_one(ar->c2s->config, "authreg.sqlite.dbname", 0);
+    const char *busy_timeout;
+    const char *dbname = config_get_one(ar->c2s->config, "authreg.sqlite.dbname", 0);
 
     log_debug(ZONE, "sqlite (authreg): start init");
 

--- a/storage/authreg_sspi.c
+++ b/storage/authreg_sspi.c
@@ -500,13 +500,13 @@ BOOL WINAPI SSPLogonUser(authreg_t ar, LPTSTR szDomain, LPTSTR szUser, LPTSTR sz
 ///////////////////////////////////////////////////////////////////////////////
 // Main jabber wrapper functions
 
-static int _ar_sspi_user_exists(authreg_t ar, char *username, char *realm)
+static int _ar_sspi_user_exists(authreg_t ar, const char *username, const char *realm)
 {
 	/* we can't check if a user exists, so we just assume we have them all the time */
 	return 1;
 }
 
-static int _ar_sspi_check_password(authreg_t ar, char *username, char *realm, char password[257])
+static int _ar_sspi_check_password(authreg_t ar, const char *username, const char *realm, char password[257])
 {
 	return !SSPLogonUser(ar, realm ? realm : "localhost", username, password);
 }

--- a/storage/storage_db.c
+++ b/storage/storage_db.c
@@ -42,7 +42,7 @@
 typedef struct drvdata_st {
     DB_ENV *env;
 
-    char *path;
+    const char *path;
     int sync;
 
     xht dbs;
@@ -143,7 +143,8 @@ static st_ret_t _st_db_cursor_free(st_driver_t drv, dbdata_t dbd, DBC *cursor, D
 }
 
 static void _st_db_object_serialise(os_object_t o, char **buf, int *len) {
-    char *key, *xml, *xmlstr;
+    char *key, *xmlstr;
+    const char *xml;
     void *val;
     os_type_t ot;
     int cur = 0, xlen;
@@ -522,7 +523,7 @@ static void _st_db_panic(DB_ENV *env, int errval) {
 }
 
 st_ret_t st_init(st_driver_t drv) {
-    char *path;
+    const char *path;
     int err;
     DB_ENV *env;
     drvdata_t data;

--- a/storage/storage_fs.c
+++ b/storage/storage_fs.c
@@ -60,7 +60,7 @@
 
 /** internal structure, holds our data */
 typedef struct drvdata_st {
-    char *path;
+    const char *path;
 } *drvdata_t;
 
 static st_ret_t _st_fs_add_type(st_driver_t drv, const char *type) {
@@ -100,7 +100,7 @@ static st_ret_t _st_fs_put(st_driver_t drv, const char *type, const char *owner,
     char *key;
     void *val;
     os_type_t ot;
-    char *xml;
+    const char *xml;
     int len;
 
     if(os_count(os) == 0)
@@ -165,11 +165,11 @@ static st_ret_t _st_fs_put(st_driver_t drv, const char *type, const char *owner,
 
                     switch(ot) {
                         case os_type_BOOLEAN:
-                            fprintf(f, "%s %d %d\n", key, ot, (int) val == 0 ? 0 : 1);
+                            fprintf(f, "%s %d %d\n", key, ot, val ? 1 : 0);
                             break;
                             
                         case os_type_INTEGER:
-                            fprintf(f, "%s %d %d\n", key, ot, (int) val);
+                            fprintf(f, "%s %d %ld\n", key, ot, (long) val);
                             break;
 
                         case os_type_STRING:
@@ -492,7 +492,7 @@ static void _st_fs_free(st_driver_t drv) {
 }
 
 st_ret_t st_init(st_driver_t drv) {
-    char *path;
+    const char *path;
     struct stat sbuf;
     int ret;
     drvdata_t data;

--- a/storage/storage_ldapvcard.c
+++ b/storage/storage_ldapvcard.c
@@ -103,7 +103,7 @@ ldapvcard_entry_st ldapvcard_entry[] =
     {NULL,NULL,0}
 };
 
-int processregex(char *src, const char *regex, int patterngroups, int wantedgroup, char *dest, size_t dest_size, st_driver_t drv) {
+static int processregex(char *src, const char *regex, int patterngroups, int wantedgroup, char *dest, size_t dest_size, st_driver_t drv) {
   regex_t preg;
   regmatch_t pmatch[patterngroups];
   //log_debug(ZONE,"processregex: src='%s' regex='%s'", src, regex);
@@ -439,7 +439,6 @@ retry_pubrost:
                 vals = (char **)ldap_get_values(data->ld,entry,data->uidattr);
                 if( ldap_count_values(vals) <= 0 ) {
                     ldap_value_free(vals);
-                    free(group);
                     continue;
                 }
                 strncpy(jid,vals[0],sizeof(jid)-1); jid[sizeof(jid)-1]='\0';

--- a/storage/storage_oracle.c
+++ b/storage/storage_oracle.c
@@ -55,7 +55,7 @@ static int _st_oracle_realloc(void **oblocks, int len)
 /** this is the safety check used to make sure there's always enough mem */
 #define ORACLE_SAFE(blocks, size, len) if((size) > len) len = _st_oracle_realloc((void**)&(blocks),(size));
 
-int checkOCIError(st_driver_t drv, char *szDoing, OCIError *m_ociError, sword nStatus)
+int checkOCIError(st_driver_t drv, const char *szDoing, OCIError *m_ociError, sword nStatus)
 {
   text txtErrorBuffer[512];
   ub4 nErrorCode;
@@ -108,7 +108,7 @@ int count_chars(char *src, char key)
 
 
 
-int oracle_escape_string(char *dest, int dest_length, char *src, int src_length)
+int oracle_escape_string(char *dest, int dest_length, const char *src, int src_length)
 {
   int  result = 0;
   /* src is not null ended */
@@ -232,7 +232,7 @@ static int oracle_ping(st_driver_t drv)
 
 
 
-static void _st_oracle_convert_filter_recursive(st_filter_t f, char **buf, int *buflen, int *nbuf)
+static void _st_oracle_convert_filter_recursive(st_filter_t f, const char **buf, int *buflen, int *nbuf)
 {
   st_filter_t scan;
 
@@ -297,7 +297,7 @@ static void _st_oracle_convert_filter_recursive(st_filter_t f, char **buf, int *
   }
 }
 
-static char *_st_oracle_convert_filter(st_driver_t drv, char *owner, char *filter)
+static char *_st_oracle_convert_filter(st_driver_t drv, const char *owner, const char *filter)
 {
   OracleDriverPointer data = (OracleDriverPointer) drv->private;
   char *buf = NULL, *sbuf = NULL, *cfilter;
@@ -338,13 +338,13 @@ static char *_st_oracle_convert_filter(st_driver_t drv, char *owner, char *filte
   return buf;
 }
 
-static st_ret_t _st_oracle_add_type(st_driver_t drv, char *type)
+static st_ret_t _st_oracle_add_type(st_driver_t drv, const char *type)
 {
   return st_SUCCESS;
 }
 
 
-static st_ret_t _st_oracle_put_guts(st_driver_t drv, char *type, char *owner, os_t os)
+static st_ret_t _st_oracle_put_guts(st_driver_t drv, const char *type, const char *owner, os_t os)
 {
   static const char NAD_PREFIX[] = "NAD";
   
@@ -466,7 +466,7 @@ static st_ret_t _st_oracle_put_guts(st_driver_t drv, char *type, char *owner, os
   return st_SUCCESS;
 }
 
-static st_ret_t _st_oracle_put(st_driver_t drv, char *type, char *owner, os_t os)
+static st_ret_t _st_oracle_put(st_driver_t drv, const char *type, const char *owner, os_t os)
 {
 
   if( !owner ) {
@@ -493,7 +493,7 @@ static st_ret_t _st_oracle_put(st_driver_t drv, char *type, char *owner, os_t os
   return st_SUCCESS;
 }
 
-static st_ret_t _st_oracle_get(st_driver_t drv, char *a_szType, char *owner, char *filter, os_t *os)
+static st_ret_t _st_oracle_get(st_driver_t drv, const char *a_szType, const char *owner, const char *filter, os_t *os)
 {
   OracleDriverPointer data = (OracleDriverPointer) drv->private;
   os_object_t o;
@@ -753,7 +753,7 @@ static st_ret_t _st_oracle_get(st_driver_t drv, char *a_szType, char *owner, cha
   return st_SUCCESS;
 }
 
-static int _st_oracle_count( st_driver_t drv, char *a_szType, char *owner, char *filter, int *count )
+static int _st_oracle_count( st_driver_t drv, const char *a_szType, const char *owner, const char *filter, int *count )
 {
     OracleDriverPointer data = (OracleDriverPointer) drv->private;
     const char *szStmtTemplate = "SELECT COUNT(*) FROM \"%s\" WHERE %s";
@@ -824,7 +824,7 @@ static int _st_oracle_count( st_driver_t drv, char *a_szType, char *owner, char 
     return st_SUCCESS;
 }
 
-static st_ret_t _st_oracle_delete(st_driver_t drv, char *type, char *owner, char *filter)
+static st_ret_t _st_oracle_delete(st_driver_t drv, const char *type, const char *owner, const char *filter)
 {
   OracleDriverPointer data = (OracleDriverPointer) drv->private;
   char *cond, *buf = NULL;
@@ -879,7 +879,7 @@ static st_ret_t _st_oracle_delete(st_driver_t drv, char *type, char *owner, char
   return st_SUCCESS;
 }
 
-static st_ret_t _st_oracle_replace(st_driver_t drv, char *type, char *owner, char *filter, os_t os)
+static st_ret_t _st_oracle_replace(st_driver_t drv, const char *type, const char *owner, const char *filter, os_t os)
 {
   if(oracle_ping(drv) != 0)
   {

--- a/storage/storage_pgsql.c
+++ b/storage/storage_pgsql.c
@@ -32,7 +32,7 @@
 typedef struct drvdata_st {
     PGconn *conn;
 
-    char *prefix;
+    const char *prefix;
 
     int txn;
 } *drvdata_t;
@@ -169,9 +169,8 @@ static st_ret_t _st_pgsql_put_guts(st_driver_t drv, const char *type, const char
     os_object_t o;
     char *key, *cval = NULL;
     void *val;
-    int vlen;
     os_type_t ot;
-    char *xml;
+    const char *xml;
     int xlen;
     PGresult *res;
     char tbuf[128];
@@ -200,24 +199,22 @@ static st_ret_t _st_pgsql_put_guts(st_driver_t drv, const char *type, const char
                     switch(ot) {
                         case os_type_BOOLEAN:
                             cval = val ? strdup("t") : strdup("f");
-                            vlen = 1;
                             break;
 
                         case os_type_INTEGER:
                             cval = (char *) malloc(sizeof(char) * 20);
-                            sprintf(cval, "%d", (int) val);
-                            vlen = strlen(cval);
+                            sprintf(cval, "%ld", (long int) val);
                             break;
 
                         case os_type_STRING:
                             cval = (char *) malloc(sizeof(char) * ((strlen((char *) val) * 2) + 1));
-                            vlen = PQescapeString(cval, (char *) val, strlen((char *) val));
+                            PQescapeString(cval, (char *) val, strlen((char *) val));
                             break;
 
                         case os_type_NAD:
                             nad_print((nad_t) val, 0, &xml, &xlen);
                             cval = (char *) malloc(sizeof(char) * ((xlen * 2) + 4));
-                            vlen = PQescapeString(&cval[3], xml, xlen) + 3;
+                            PQescapeString(&cval[3], xml, xlen);
                             strncpy(cval, "NAD", 3);
                             break;
 
@@ -635,7 +632,7 @@ static void _st_pgsql_free(st_driver_t drv) {
 }
 
 st_ret_t st_init(st_driver_t drv) {
-    char *host, *port, *dbname, *user, *pass, *conninfo;
+    const char *host, *port, *dbname, *user, *pass, *conninfo;
     PGconn *conn;
     drvdata_t data;
 

--- a/storage/storage_sqlite.c
+++ b/storage/storage_sqlite.c
@@ -33,7 +33,7 @@
 /** internal structure, holds our data */
 typedef struct drvdata_st {
     sqlite3 *db;
-    char *prefix;
+    const char *prefix;
     int txn;
 } *drvdata_t;
 
@@ -223,7 +223,7 @@ static st_ret_t _st_sqlite_put_guts (st_driver_t drv, const char *type,
     char *key, *cval = NULL;
     void *val;
     os_type_t ot;
-    char *xml;
+    const char *xml;
     int xlen;
     char tbuf[128];
     int res;
@@ -296,11 +296,11 @@ static st_ret_t _st_sqlite_put_guts (st_driver_t drv, const char *type,
 
 		    switch(ot) {
 		     case os_type_BOOLEAN:
-		      sqlite3_bind_int (stmt, i + 2, (int) val ? 1 : 0);
+		      sqlite3_bind_int (stmt, i + 2, val ? 1 : 0);
 		      break;
 
 		     case os_type_INTEGER:
-		      sqlite3_bind_int (stmt, i + 2, (int) val);
+		      sqlite3_bind_int (stmt, i + 2, (long)val); // HACK ugly hack for pointer-to-int-cast
 		      break;
 
 		     case os_type_STRING:
@@ -677,11 +677,11 @@ static void _st_sqlite_free (st_driver_t drv) {
 
 DLLEXPORT st_ret_t st_init(st_driver_t drv) {
 
-    char *dbname;
+    const char *dbname;
     sqlite3 *db;
     drvdata_t data;
     int ret;
-    char *busy_timeout;
+    const char *busy_timeout;
 
     dbname = config_get_one (drv->st->config,
 			     "storage.sqlite.dbname", 0);

--- a/subst/getopt.c
+++ b/subst/getopt.c
@@ -330,7 +330,7 @@ static void exchange(char **argv)
    If LONG_ONLY is nonzero, '-' as well as '--' can introduce
    long-named options.  */
 
-int _getopt_internal(int argc, char *const *argv, const char *optstring,
+int _getopt_internal(int argc, const char *const *argv, const char *optstring,
 		     const struct option *longopts, int *longind, int long_only)
 {
 	int option_index;
@@ -618,12 +618,12 @@ int _getopt_internal(int argc, char *const *argv, const char *optstring,
 	}
 }
 
-int getopt(int argc, char *const *argv, const char *optstring)
+int getopt(int argc, const char *const *argv, const char *optstring)
 {
 	return _getopt_internal(argc, argv, optstring, (const struct option *) 0, (int *) 0, 0);
 }
 
-int getopt_long(int argc, char *const *argv, const char *options, const struct option long_options, int *opt_index)
+int getopt_long(int argc, const char *const *argv, const char *options, const struct option long_options, int *opt_index)
 {
 	return _getopt_internal(argc, argv, options, &long_options, opt_index, 0);
 }
@@ -635,7 +635,7 @@ int getopt_long(int argc, char *const *argv, const char *options, const struct o
 /* Compile with -DTEST to make an executable for use in testing
    the above definition of `getopt'.  */
 
-int main(int argc, char **argv)
+int main(int argc, const char **argv)
 {
 	int c;
 	int digit_optind = 0;

--- a/subst/getopt.h
+++ b/subst/getopt.h
@@ -112,16 +112,16 @@ struct option
 /* Many other libraries have conflicting prototypes for getopt, with
    differences in the consts, in stdlib.h.  To avoid compilation
    errors, only prototype getopt for the GNU C library.  */
-JABBERD2_API int getopt (int argc, char *const *argv, const char *shortopts);
+JABBERD2_API int getopt (int argc, const char *const *argv, const char *shortopts);
 #endif /* not __GNU_LIBRARY__ */
-JABBERD2_API int getopt_long (int argc, char *const *argv, const char *shortopts,
+JABBERD2_API int getopt_long (int argc, const char *const *argv, const char *shortopts,
 		        const struct option *longopts, int *longind);
-JABBERD2_API int getopt_long_only (int argc, char *const *argv,
+JABBERD2_API int getopt_long_only (int argc, const char *const *argv,
 			     const char *shortopts,
 		             const struct option *longopts, int *longind);
 
 /* Internal only.  Users should not call this directly.  */
-JABBERD2_API int _getopt_internal (int argc, char *const *argv,
+JABBERD2_API int _getopt_internal (int argc, const char *const *argv,
 			     const char *shortopts,
 		             const struct option *longopts, int *longind,
 			     int long_only);

--- a/sx/client.c
+++ b/sx/client.c
@@ -108,7 +108,7 @@ static void _sx_client_notify_header(sx_t s, void *arg) {
     s->want_read = 1;
 }
 
-void sx_client_init(sx_t s, unsigned int flags, char *ns, char *to, char *from, char *version) {
+void sx_client_init(sx_t s, unsigned int flags, const char *ns, const char *to, const char *from, const char *version) {
     sx_buf_t buf;
     char *c;
     int i, len;

--- a/sx/compress.c
+++ b/sx/compress.c
@@ -343,7 +343,7 @@ int sx_compress_init(sx_env_t env, sx_plugin_t p, va_list args) {
     return 0;
 }
 
-int sx_compress_client_compress(sx_plugin_t p, sx_t s, char *pemfile) {
+int sx_compress_client_compress(sx_plugin_t p, sx_t s, const char *pemfile) {
     assert((int) (p != NULL));
     assert((int) (s != NULL));
 

--- a/sx/io.c
+++ b/sx/io.c
@@ -87,7 +87,7 @@ void _sx_process_read(sx_t s, sx_buf_t buf) {
         while((nad = jqueue_pull(s->rnadq)) != NULL) {
             int plugin_error;
 #ifdef SX_DEBUG
-            char *out; int len;
+            const char *out; int len;
             nad_print(nad, 0, &out, &len);
             _sx_debug(ZONE, "completed nad: %.*s", len, out);
 #endif
@@ -113,7 +113,7 @@ void _sx_process_read(sx_t s, sx_buf_t buf) {
 
                 /* if not available, log the whole packet for debugging */
                 if (errstring == NULL) {
-                    char *xml;
+                    const char *xml;
                     int xlen;
 
                     nad_print(nad, 0, &xml, &xlen);
@@ -386,7 +386,7 @@ int sx_can_write(sx_t s) {
 
 /** send a new nad out */
 int _sx_nad_write(sx_t s, nad_t nad, int elem) {
-    char *out;
+    const char *out;
     int len;
 
     /* silently drop it if we're closing or closed */
@@ -432,7 +432,7 @@ void sx_nad_write_elem(sx_t s, nad_t nad, int elem) {
 }
 
 /** send raw data out */
-int _sx_raw_write(sx_t s, char *buf, int len) {
+int _sx_raw_write(sx_t s, const char *buf, int len) {
     /* siltently drop it if we're closing or closed */
     if(s->state >= state_CLOSING) {
         log_debug(ZONE, "stream closed, dropping outgoing raw data");
@@ -451,7 +451,7 @@ int _sx_raw_write(sx_t s, char *buf, int len) {
 }
 
 /** app version */
-void sx_raw_write(sx_t s, char *buf, int len) {
+void sx_raw_write(sx_t s, const char *buf, int len) {
     assert((int) (s != NULL));
     assert((int) (buf != NULL));
     assert(len);

--- a/sx/plugins.h
+++ b/sx/plugins.h
@@ -65,10 +65,10 @@ extern "C" {
 JABBERD2_API int                         sx_ssl_init(sx_env_t env, sx_plugin_t p, va_list args);
 
 /** add cert function */
-JABBERD2_API int                         sx_ssl_server_addcert(sx_plugin_t p, char *name, char *pemfile, char *cachain, int mode);
+JABBERD2_API int                         sx_ssl_server_addcert(sx_plugin_t p, const char *name, const char *pemfile, const char *cachain, int mode);
 
 /** trigger for client starttls */
-JABBERD2_API int                         sx_ssl_client_starttls(sx_plugin_t p, sx_t s, char *pemfile);
+JABBERD2_API int                         sx_ssl_client_starttls(sx_plugin_t p, sx_t s, const char *pemfile);
 
 /* previous states */
 #define SX_SSL_STATE_NONE       (0)
@@ -116,7 +116,7 @@ typedef int                 (*sx_sasl_callback_t)(int cb, void *arg, void **res,
 #define sx_sasl_ret_FAIL	    (1)
 
 /** trigger for client auth */
-JABBERD2_API int                         sx_sasl_auth(sx_plugin_t p, sx_t s, char *appname, char *mech, char *user, char *pass);
+JABBERD2_API int                         sx_sasl_auth(sx_plugin_t p, sx_t s, const char *appname, const char *mech, const char *user, const char *pass);
 
 /* for passing auth data to callback */
 typedef struct sx_sasl_creds_st {

--- a/sx/sasl_cyrus.c
+++ b/sx/sasl_cyrus.c
@@ -229,7 +229,7 @@ static int _sx_sasl_checkpass(sasl_conn_t *conn, void *ctx, const char *user, co
  * the user
  */
 
-static int _sx_sasl_canon_user(sasl_conn_t *conn, void *ctx, const char *user, unsigned ulen, unsigned flags, const char *user_realm, char *out_user, unsigned out_umax, unsigned *out_ulen) {
+static int _sx_sasl_canon_user(sasl_conn_t *conn, void *ctx, const char *user, unsigned ulen, unsigned flags, const char *user_realm, const char *out_user, unsigned out_umax, unsigned *out_ulen) {
     char *buf;
     _sx_sasl_data_t sd = (_sx_sasl_data_t)ctx;
     sasl_getprop(conn, SASL_MECHNAME, (const void **) &buf);
@@ -675,7 +675,7 @@ static nad_t _sx_sasl_failure(sx_t s, const char *err) {
 }
 
 /** utility: generate a challenge nad */
-static nad_t _sx_sasl_challenge(sx_t s, char *data, int dlen) {
+static nad_t _sx_sasl_challenge(sx_t s, const char *data, int dlen) {
     nad_t nad;
     int ns;
 
@@ -690,7 +690,7 @@ static nad_t _sx_sasl_challenge(sx_t s, char *data, int dlen) {
 }
 
 /** utility: generate a response nad */
-static nad_t _sx_sasl_response(sx_t s, char *data, int dlen) {
+static nad_t _sx_sasl_response(sx_t s, const char *data, int dlen) {
     nad_t nad;
     int ns;
 
@@ -742,7 +742,7 @@ static void _sx_sasl_notify_success(sx_t s, void *arg) {
 }
 
 /** process handshake packets from the client */
-static void _sx_sasl_client_process(sx_t s, sx_plugin_t p, char *mech, char *in, int inlen) {
+static void _sx_sasl_client_process(sx_t s, sx_plugin_t p, const char *mech, const char *in, int inlen) {
     _sx_sasl_data_t sd = (_sx_sasl_data_t) s->plugin_data[p->index];
     char *buf = NULL, *out = NULL;
     int buflen, outlen, ret;
@@ -810,7 +810,7 @@ static void _sx_sasl_client_process(sx_t s, sx_plugin_t p, char *mech, char *in,
 }
 
 /** process handshake packets from the server */
-static void _sx_sasl_server_process(sx_t s, sx_plugin_t p, char *in, int inlen) {
+static void _sx_sasl_server_process(sx_t s, sx_plugin_t p, const char *in, int inlen) {
     _sx_sasl_data_t sd = (_sx_sasl_data_t)s->plugin_data[p->index];
     char *buf, *out;
     int buflen, outlen, ret;
@@ -1036,7 +1036,7 @@ int sx_sasl_init(sx_env_t env, sx_plugin_t p, va_list args) {
 
     _sx_debug(ZONE, "initialising sasl plugin");
 
-    appname = va_arg(args, char *);
+    appname = va_arg(args, const char *);
     if(appname == NULL) {
         _sx_debug(ZONE, "appname was NULL, failing");
         return 1;
@@ -1138,7 +1138,7 @@ static int _sx_sasl_cb_get_secret(sasl_conn_t *conn, void *ctx, int id, sasl_sec
 }
 
 /** kick off the auth handshake */
-int sx_sasl_auth(sx_plugin_t p, sx_t s, char *appname, char *mech, char *user, char *pass) {
+int sx_sasl_auth(sx_plugin_t p, sx_t s, const char *appname, const char *mech, const char *user, const char *pass) {
     _sx_sasl_t ctx = (_sx_sasl_t) p->private;
     _sx_sasl_data_t sd;
     char *buf, *out, *ext_id;

--- a/sx/sasl_gsasl.c
+++ b/sx/sasl_gsasl.c
@@ -138,7 +138,7 @@ struct _Gsasl_digest_md5_server_state
 typedef struct _Gsasl_digest_md5_server_state _Gsasl_digest_md5_server_state;
 
 /** utility: generate a success nad */
-static nad_t _sx_sasl_success(sx_t s, char *data, int dlen) {
+static nad_t _sx_sasl_success(sx_t s, const char *data, int dlen) {
     nad_t nad;
     int ns;
 
@@ -168,7 +168,7 @@ static nad_t _sx_sasl_failure(sx_t s, const char *err) {
 }
 
 /** utility: generate a challenge nad */
-static nad_t _sx_sasl_challenge(sx_t s, char *data, int dlen) {
+static nad_t _sx_sasl_challenge(sx_t s, const char *data, int dlen) {
     nad_t nad;
     int ns;
 
@@ -183,7 +183,7 @@ static nad_t _sx_sasl_challenge(sx_t s, char *data, int dlen) {
 }
 
 /** utility: generate a response nad */
-static nad_t _sx_sasl_response(sx_t s, char *data, int dlen) {
+static nad_t _sx_sasl_response(sx_t s, const char *data, int dlen) {
     nad_t nad;
     int ns;
 
@@ -403,7 +403,7 @@ static void _sx_sasl_notify_success(sx_t s, void *arg) {
 }
 
 /** process handshake packets from the client */
-static void _sx_sasl_client_process(sx_t s, sx_plugin_t p, Gsasl_session *sd, char *mech, char *in, int inlen) {
+static void _sx_sasl_client_process(sx_t s, sx_plugin_t p, Gsasl_session *sd, const char *mech, const char *in, int inlen) {
     _sx_sasl_t ctx = (_sx_sasl_t) p->private;
     char *buf = NULL, *out = NULL, *realm = NULL, **ext_id;
     char hostname[256];
@@ -588,7 +588,7 @@ static void _sx_sasl_client_process(sx_t s, sx_plugin_t p, Gsasl_session *sd, ch
 }
 
 /** process handshake packets from the server */
-static void _sx_sasl_server_process(sx_t s, sx_plugin_t p, Gsasl_session *sd, char *in, int inlen) {
+static void _sx_sasl_server_process(sx_t s, sx_plugin_t p, Gsasl_session *sd, const char *in, int inlen) {
     char *buf = NULL, *out = NULL;
     size_t buflen, outlen;
     int ret;
@@ -924,7 +924,7 @@ static void _sx_sasl_unload(sx_plugin_t p) {
 
 /** args: appname, callback, cb arg */
 int sx_sasl_init(sx_env_t env, sx_plugin_t p, va_list args) {
-    char *appname;
+    const char *appname;
     sx_sasl_callback_t cb;
     void *cbarg;
     _sx_sasl_t ctx;
@@ -932,7 +932,7 @@ int sx_sasl_init(sx_env_t env, sx_plugin_t p, va_list args) {
 
     _sx_debug(ZONE, "initialising sasl plugin");
 
-    appname = va_arg(args, char *);
+    appname = va_arg(args, const char *);
     if(appname == NULL) {
         _sx_debug(ZONE, "appname was NULL, failing");
         return 1;
@@ -976,7 +976,7 @@ int sx_sasl_init(sx_env_t env, sx_plugin_t p, va_list args) {
 }
 
 /** kick off the auth handshake */
-int sx_sasl_auth(sx_plugin_t p, sx_t s, char *appname, char *mech, char *user, char *pass) {
+int sx_sasl_auth(sx_plugin_t p, sx_t s, const char *appname, const char *mech, const char *user, const char *pass) {
     _sx_sasl_t ctx = (_sx_sasl_t) p->private;
     Gsasl_session *sd;
     char *buf = NULL, *out = NULL;

--- a/sx/server.c
+++ b/sx/server.c
@@ -23,7 +23,7 @@
 static void _sx_server_notify_header(sx_t s, void *arg) {
     int i, ns, len;
     nad_t nad;
-    char *c;
+    const char *c;
     sx_buf_t buf;
 
     _sx_debug(ZONE, "stream established");
@@ -98,7 +98,7 @@ static void _sx_server_element_start(void *arg, const char *name, const char **a
     attr = atts;
     while(attr[0] != NULL) {
         if(!tflag && strcmp(attr[0], "to") == 0) {
-            if(s->req_to != NULL) free(s->req_to);
+            if(s->req_to != NULL) free((void*)s->req_to);
             s->req_to = strdup(attr[1]);
             tflag = 1;
         }

--- a/sx/ssl.c
+++ b/sx/ssl.c
@@ -33,7 +33,6 @@ static int _sx_ssl_verify_callback(int preverify_ok, X509_STORE_CTX *ctx)
     char    buf[256];
     X509   *err_cert;
     int     err, depth;
-    SSL    *ssl;
 
     err_cert = X509_STORE_CTX_get_current_cert(ctx);
     err = X509_STORE_CTX_get_error(ctx);
@@ -52,7 +51,6 @@ static int _sx_ssl_verify_callback(int preverify_ok, X509_STORE_CTX *ctx)
      * Retrieve the pointer to the SSL of the connection currently treated
      * and the application specific data stored into the SSL object.
      */
-    ssl = X509_STORE_CTX_get_ex_data(ctx, SSL_get_ex_data_X509_STORE_CTX_idx());
     X509_NAME_oneline(X509_get_subject_name(err_cert), buf, 256);
 
     if (!preverify_ok) {
@@ -811,21 +809,21 @@ int sx_openssl_initialized = 0;
 
 /** args: name, pemfile, cachain, mode */
 int sx_ssl_init(sx_env_t env, sx_plugin_t p, va_list args) {
-    char *name, *pemfile, *cachain;
+    const char *name, *pemfile, *cachain;
     int ret;
     int mode;
 
     _sx_debug(ZONE, "initialising ssl plugin");
 
-    name = va_arg(args, char *);
-    pemfile = va_arg(args, char *);
+    name = va_arg(args, const char *);
+    pemfile = va_arg(args, const char *);
     if(pemfile == NULL)
         return 1;
 
     if(p->private != NULL)
         return 1;
 
-    cachain = va_arg(args, char *);
+    cachain = va_arg(args, const char *);
     mode = va_arg(args, int);
 
     /* !!! output openssl error messages to the debug log */
@@ -857,7 +855,7 @@ int sx_ssl_init(sx_env_t env, sx_plugin_t p, va_list args) {
 }
 
 /** args: name, pemfile, cachain, mode */
-int sx_ssl_server_addcert(sx_plugin_t p, char *name, char *pemfile, char *cachain, int mode) {
+int sx_ssl_server_addcert(sx_plugin_t p, const char *name, const char *pemfile, const char *cachain, int mode) {
     xht contexts = (xht) p->private;
     SSL_CTX *ctx;
     SSL_CTX *tmp;
@@ -980,7 +978,7 @@ int sx_ssl_server_addcert(sx_plugin_t p, char *name, char *pemfile, char *cachai
     return 0;
 }
 
-int sx_ssl_client_starttls(sx_plugin_t p, sx_t s, char *pemfile) {
+int sx_ssl_client_starttls(sx_plugin_t p, sx_t s, const char *pemfile) {
     assert((int) (p != NULL));
     assert((int) (s != NULL));
 

--- a/sx/sx.c
+++ b/sx/sx.c
@@ -82,17 +82,17 @@ void sx_free(sx_t s) {
 
     _sx_debug(ZONE, "freeing sx for %d", s->tag);
 
-    if(s->ns != NULL) free(s->ns);
+    if(s->ns != NULL) free((void*)s->ns);
 
-    if(s->req_to != NULL) free(s->req_to);
-    if(s->req_from != NULL) free(s->req_from);
-    if(s->req_version != NULL) free(s->req_version);
+    if(s->req_to != NULL) free((void*)s->req_to);
+    if(s->req_from != NULL) free((void*)s->req_from);
+    if(s->req_version != NULL) free((void*)s->req_version);
 
-    if(s->res_to != NULL) free(s->res_to);
-    if(s->res_from != NULL) free(s->res_from);
-    if(s->res_version != NULL) free(s->res_version);
+    if(s->res_to != NULL) free((void*)s->res_to);
+    if(s->res_from != NULL) free((void*)s->res_from);
+    if(s->res_version != NULL) free((void*)s->res_version);
 
-    if(s->id != NULL) free(s->id);
+    if(s->id != NULL) free((void*)s->id);
 
     while((buf = jqueue_pull(s->wbufq)) != NULL)
         _sx_buffer_free(buf);
@@ -109,8 +109,8 @@ void sx_free(sx_t s) {
 
     if(s->nad != NULL) nad_free(s->nad);
 
-    if(s->auth_method != NULL) free(s->auth_method);
-    if(s->auth_id != NULL) free(s->auth_id);
+    if(s->auth_method != NULL) free((void*)s->auth_method);
+    if(s->auth_id != NULL) free((void*)s->auth_id);
 
     if(s->env != NULL) {
         _sx_debug(ZONE, "freeing %d env plugins", s->env->nplugins);
@@ -299,7 +299,7 @@ void _sx_buffer_alloc_margin(sx_buf_t buf, int before, int after)
 }
 
 /** utility: reset a sx_buf_t's contents. If newheap is non-NULL it is assumed to be 'data's malloc block and ownership of the block is taken by the buffer. If newheap is NULL then the data is copied. */
-void _sx_buffer_set(sx_buf_t buf, char *newdata, int newlength, char *newheap)
+void _sx_buffer_set(sx_buf_t buf, char* newdata, int newlength, char* newheap)
 {
     if (newheap == NULL) {
         buf->len = 0;

--- a/sx/sx.h
+++ b/sx/sx.h
@@ -98,8 +98,8 @@ typedef int (*sx_plugin_init_t)(sx_env_t env, sx_plugin_t p, va_list args);
 /** error info for event_ERROR */
 typedef struct _sx_error_st {
     int                     code;
-    char                    *generic;
-    char                    *specific;
+    const char              *generic;
+    const char              *specific;
 } sx_error_t;
 
 /** helper macro to populate this struct */
@@ -154,7 +154,7 @@ JABBERD2_API sx_t                        sx_new(sx_env_t env, int tag, sx_callba
 JABBERD2_API void                        sx_free(sx_t s);
 
 /* get things ready */
-JABBERD2_API void                        sx_client_init(sx_t s, unsigned int flags, char *ns, char *to, char *from, char *version);
+JABBERD2_API void                        sx_client_init(sx_t s, unsigned int flags, const char *ns, const char *to, const char *from, const char *version);
 JABBERD2_API void                        sx_server_init(sx_t s, unsigned int flags);
 
 /* activity on socket, do stuff! (returns 1 if more read/write actions wanted, 0 otherwise) */
@@ -166,7 +166,7 @@ JABBERD2_API void                        sx_nad_write_elem(sx_t s, nad_t nad, in
 #define sx_nad_write(s,nad) sx_nad_write_elem(s, nad, 0)
 
 /** sending raw data */
-JABBERD2_API void                        sx_raw_write(sx_t s, char *buf, int len);
+JABBERD2_API void                        sx_raw_write(sx_t s, const char *buf, int len);
 
 /** authenticate the stream and move to the auth'd state */
 JABBERD2_API void                        sx_auth(sx_t s, const char *auth_method, const char *auth_id);
@@ -228,7 +228,7 @@ JABBERD2_API void                        _sx_buffer_set(sx_buf_t buf, char *newd
 JABBERD2_API int                         _sx_nad_write(sx_t s, nad_t nad, int elem);
 
 /** sending raw data (internal) */
-JABBERD2_API void                        sx_raw_write(sx_t s, char *buf, int len);
+JABBERD2_API void                        sx_raw_write(sx_t s, const char *buf, int len);
 
 /** reset stream state without informing the app */
 JABBERD2_API void                        _sx_reset(sx_t s);
@@ -257,7 +257,7 @@ struct _sx_st {
 
 	/* IP address of the connection */
 	/* pointing to sess.ip and owned by sess structure */
-	char                    *ip;
+	const char              *ip;
 
 	/* TCP port of the connection */
 	/* pointing to sess.port and owned by sess structure */
@@ -274,20 +274,20 @@ struct _sx_st {
     unsigned int             flags;
 
     /* application namespace */
-    char                    *ns;
+    const char              *ns;
 
     /* requested stream properties */
-    char                    *req_to;
-    char                    *req_from;
-    char                    *req_version;
+    const char              *req_to;
+    const char              *req_from;
+    const char              *req_version;
 
     /* responded stream properties */
-    char                    *res_to;
-    char                    *res_from;
-    char                    *res_version;
+    const char              *res_to;
+    const char              *res_from;
+    const char              *res_version;
 
     /* stream id */
-    char                    *id;
+    const char              *id;
 
     /* io chain */
     _sx_chain_t              wio, rio;
@@ -324,8 +324,8 @@ struct _sx_st {
     void                   **plugin_data;
 
     /* type and id of auth */
-    char                    *auth_method;
-    char                    *auth_id;
+    const char              *auth_method;
+    const char              *auth_id;
 
     /* if true, then we were called from the callback */
     int                     reentry;

--- a/tests/check_nad.c
+++ b/tests/check_nad.c
@@ -91,7 +91,7 @@ mateamargonerds'/><point xmlns='http://www.georss.org/georss'>-33.4262838 -70.56
 
 START_TEST (check_s2s_wrap)
 {
-    char *buf;
+    const char *buf;
     int len, ns, sns, elem;
 
     nad_t nad = nad_parse(nadtxt[_i], 0);
@@ -166,7 +166,7 @@ END_TEST
 
 START_TEST (check_leaf_path)
 {
-    char *buf;
+    const char *buf;
     int len, elem;
 
     const char *nad_test =

--- a/util/access.c
+++ b/util/access.c
@@ -160,7 +160,7 @@ static int _access_check_match(struct sockaddr_storage *ip_1, struct sockaddr_st
     return 0;
 }
 
-int access_allow(access_t access, char *ip, char *mask)
+int access_allow(access_t access, const char *ip, const char *mask)
 {
     struct sockaddr_storage ip_addr;
     int netsize;
@@ -180,7 +180,7 @@ int access_allow(access_t access, char *ip, char *mask)
     return 0;
 }
 
-int access_deny(access_t access, char *ip, char *mask)
+int access_deny(access_t access, const char *ip, const char *mask)
 {
     struct sockaddr_storage ip_addr;
     int netsize;
@@ -200,7 +200,7 @@ int access_deny(access_t access, char *ip, char *mask)
     return 0;
 }
 
-int access_check(access_t access, char *ip)
+int access_check(access_t access, const char *ip)
 {
     struct sockaddr_storage addr;
     access_rule_t rule;

--- a/util/config.c
+++ b/util/config.c
@@ -346,7 +346,7 @@ static char *_config_expandx(config_t c, const char *value, int l)
 
     char *var_start, *var_end;
 
-    while (var_start = strstr(s, "${")) {
+    while ((var_start = strstr(s, "${")) != 0) {
 //         fprintf(stderr, "config_expand: processing '%s'\n", s);
         var_end = strstr(var_start + 2, "}");
 

--- a/util/datetime.h
+++ b/util/datetime.h
@@ -55,6 +55,6 @@ typedef enum {
 } datetime_t;
 
 JABBERD2_API time_t  datetime_in(char *date);
-JABBERD2_API void    datetime_out(time_t t, datetime_t type, char *date, int datelen);
+JABBERD2_API void    datetime_out(time_t t, datetime_t type, const char *date, int datelen);
 
 #endif

--- a/util/hex.c
+++ b/util/hex.c
@@ -23,7 +23,7 @@
 #include "util.h"
 
 /** turn raw into hex - out must be (inlen*2)+1 */
-void hex_from_raw(char *in, int inlen, char *out) {
+void hex_from_raw(const char *in, int inlen, char *out) {
     int i, h, l;
 
     for(i = 0; i < inlen; i++) {
@@ -37,7 +37,7 @@ void hex_from_raw(char *in, int inlen, char *out) {
 }
 
 /** turn hex into raw - out must be (inlen/2) */
-int hex_to_raw(char *in, int inlen, char *out) {
+int hex_to_raw(const char *in, int inlen, char *out) {
     int i, o, h, l;
 
     /* need +ve even input */

--- a/util/inaddr.c
+++ b/util/inaddr.c
@@ -43,7 +43,7 @@
  * @param dst the struct sockaddr_storage that should get the new address
  * @return 1 on success, 0 if address is not valid
  */
-int j_inet_pton(char *src, struct sockaddr_storage *dst)
+int j_inet_pton(const char *src, struct sockaddr_storage *dst)
 {
 #ifndef HAVE_INET_PTON
     struct sockaddr_in *sin;

--- a/util/inaddr.h
+++ b/util/inaddr.h
@@ -70,8 +70,8 @@ extern "C" {
 
 #include <util/util_compat.h>
 
-JABBERD2_API int         j_inet_pton(char *src, struct sockaddr_storage *dst);
-JABBERD2_API const char  *j_inet_ntop(struct sockaddr_storage *src, char *dst, size_t size);
+JABBERD2_API int         j_inet_pton(const char *src, struct sockaddr_storage *dst);
+JABBERD2_API const char *j_inet_ntop(struct sockaddr_storage* src, char* dst, size_t size);
 JABBERD2_API int         j_inet_getport(struct sockaddr_storage *sa);
 JABBERD2_API int	     j_inet_setport(struct sockaddr_storage *sa, in_port_t port);
 JABBERD2_API socklen_t   j_inet_addrlen(struct sockaddr_storage *sa);

--- a/util/log.h
+++ b/util/log.h
@@ -47,13 +47,13 @@ typedef enum {
 /* opaque decl */
 typedef struct _log_st *log_t;
 
-JABBERD2_API log_t    log_new(pool_t p, log_type_t type, char *ident, char *facility);
+JABBERD2_API log_t    log_new(pool_t p, log_type_t type, const char *ident, const char *facility);
 JABBERD2_API void     log_write(log_t log, int level, const char *msgfmt, ...);
 
 /* debug logging */
 #if defined(DEBUG) && 0
 JABBERD2_API int      log_debug_flag;
-void            log_debug(char *file, int line, char *subsys, const char *msgfmt, ...);
+void            log_debug(char *file, int line, const char *subsys, const char *msgfmt, ...);
 
 # define        log_debug_get_flag()    log_debug_flag
 # define        log_debug_set_flag(f)   (log_debug_flag = f ? 1 : 0)

--- a/util/nad.c
+++ b/util/nad.c
@@ -1112,7 +1112,7 @@ static int _nad_lp0(nad_t nad, int elem)
     return elem;
 }
 
-void nad_print(nad_t nad, int elem, char **xml, int *len)
+void nad_print(nad_t nad, int elem, const char **xml, int *len)
 {
     int ixml = nad->ccur;
 

--- a/util/nad.h
+++ b/util/nad.h
@@ -170,7 +170,7 @@ JABBERD2_API int nad_add_namespace(nad_t nad, const char *uri, const char *prefi
 JABBERD2_API int nad_append_namespace(nad_t nad, int elem, const char *uri, const char *prefix);
 
 /** create a string representation of the given element (and children), point references to it */
-JABBERD2_API void nad_print(nad_t nad, int elem, char **xml, int *len);
+JABBERD2_API void nad_print(nad_t nad, int elem, const char **xml, int *len);
 
 /** serialize and deserialize a nad */
 JABBERD2_API void nad_serialize(nad_t nad, char **buf, int *len);

--- a/util/pool.c
+++ b/util/pool.c
@@ -42,7 +42,7 @@ void _pool__free(void *block)
 
 
 /** make an empty pool */
-pool_t _pool_new(char *zone, int line)
+pool_t _pool_new(const char *zone, int line)
 {
     pool_t p;
     while((p = _pool__malloc(sizeof(_pool))) == NULL) sleep(1);
@@ -130,7 +130,7 @@ static struct pheap *_pool_heap(pool_t p, int size)
     return ret;
 }
 
-pool_t _pool_new_heap(int size, char *zone, int line)
+pool_t _pool_new_heap(int size, const char *zone, int line)
 {
     pool_t p;
     p = _pool_new(zone, line);

--- a/util/pool.h
+++ b/util/pool.h
@@ -97,8 +97,8 @@ typedef struct pool_struct
 # define pool_new() _pool_new(NULL,0)
 #endif
 
-JABBERD2_API pool_t _pool_new(char *file, int line); /* new pool :) */
-JABBERD2_API pool_t _pool_new_heap(int size, char *file, int line); /* creates a new memory pool with an initial heap size */
+JABBERD2_API pool_t _pool_new(const char *file, int line); /* new pool :) */
+JABBERD2_API pool_t _pool_new_heap(int size, const char *file, int line); /* creates a new memory pool with an initial heap size */
 JABBERD2_API void *pmalloc(pool_t, int size); /* wrapper around malloc, takes from the pool, cleaned up automatically */
 JABBERD2_API void *pmalloc_x(pool_t p, int size, char c); /* Wrapper around pmalloc which prefils buffer with c */
 JABBERD2_API void *pmalloco(pool_t p, int size); /* YAPW for zeroing the block */

--- a/util/serial.c
+++ b/util/serial.c
@@ -108,7 +108,7 @@ static int _ser_realloc(void **oblocks, int len)
 /** this is the safety check used to make sure there's always enough mem */
 #define SER_SAFE(blocks, size, len) if((size) > len) len = _ser_realloc((void**)&(blocks),(size));
 
-void ser_string_set(char *source, int *dest, char **buf, int *len)
+void ser_string_set(const char *source, int *dest, char **buf, int *len)
 {
     int need = sizeof(char) * (strlen(source) + 1);
 

--- a/util/str.c
+++ b/util/str.c
@@ -29,7 +29,7 @@ char *j_strdup(const char *str)
         return strdup(str);
 }
 
-char *j_strcat(char *dest, char *txt)
+char *j_strcat(char *dest, const char *txt)
 {
     if(!txt) return(dest);
 
@@ -128,7 +128,7 @@ spool spool_new(pool_t p)
     return s;
 }
 
-static void _spool_add(spool s, char *goodstr)
+static void _spool_add(spool s, const char *goodstr)
 {
     struct spool_node *sn;
 
@@ -144,7 +144,7 @@ static void _spool_add(spool s, char *goodstr)
         s->first = sn;
 }
 
-void spool_add(spool s, char *str)
+void spool_add(spool s, const char *str)
 {
     if(str == NULL || strlen(str) == 0)
         return;
@@ -152,7 +152,7 @@ void spool_add(spool s, char *str)
     _spool_add(s, pstrdup(s->p, str));
 }
 
-void spool_escape(spool s, char *raw, int len)
+void spool_escape(spool s, const char *raw, int len)
 {
     if(raw == NULL || len <= 0)
         return;
@@ -183,7 +183,7 @@ void spooler(spool s, ...)
     va_end(ap);
 }
 
-char *spool_print(spool s)
+const char *spool_print(spool s)
 {
     char *ret,*tmp;
     struct spool_node *next;
@@ -206,7 +206,7 @@ char *spool_print(spool s)
 }
 
 /** convenience :) */
-char *spools(pool_t p, ...)
+const char *spools(pool_t p, ...)
 {
     va_list ap;
     spool s;
@@ -282,7 +282,7 @@ char *strunescape(pool_t p, char *buf)
 }
 
 
-char *strescape(pool_t p, char *buf, int len)
+char *strescape(pool_t p, const char *buf, int len)
 {
     int i,j,newlen = len;
     char *temp;

--- a/util/util.h
+++ b/util/util.h
@@ -112,7 +112,7 @@ extern "C" {
 /*                                                           */
 /** --------------------------------------------------------- */
 JABBERD2_API char *j_strdup(const char *str); /* provides NULL safe strdup wrapper */
-JABBERD2_API char *j_strcat(char *dest, char *txt); /* strcpy() clone */
+JABBERD2_API char *j_strcat(char *dest, const char *txt); /* strcpy() clone */
 JABBERD2_API int j_strcmp(const char *a, const char *b); /* provides NULL safe strcmp wrapper */
 JABBERD2_API int j_strcasecmp(const char *a, const char *b); /* provides NULL safe strcasecmp wrapper */
 JABBERD2_API int j_strncmp(const char *a, const char *b, int i); /* provides NULL safe strncmp wrapper */
@@ -131,8 +131,8 @@ JABBERD2_API void shahash_raw(const char* str, unsigned char hashval[20]);
 /* XML escaping utils                                        */
 /*                                                           */
 /* --------------------------------------------------------- */
-JABBERD2_API char *strescape(pool_t p, char *buf, int len); /* Escape <>&'" chars */
-JABBERD2_API char *strunescape(pool_t p, char *buf);
+JABBERD2_API char *strescape(pool_t p, const char *buf, int len); /* Escape <>&'" chars */
+JABBERD2_API char *strunescape(pool_t p, char* buf);
 
 
 /* --------------------------------------------------------- */
@@ -142,7 +142,7 @@ JABBERD2_API char *strunescape(pool_t p, char *buf);
 /* --------------------------------------------------------- */
 struct spool_node
 {
-    char *c;
+    const char *c;
     struct spool_node *next;
 };
 
@@ -156,10 +156,10 @@ typedef struct spool_struct
 
 JABBERD2_API spool spool_new(pool_t p); /* create a string pool */
 JABBERD2_API void spooler(spool s, ...); /* append all the char * args to the pool, terminate args with s again */
-JABBERD2_API char *spool_print(spool s); /* return a big string */
-JABBERD2_API void spool_add(spool s, char *str); /* add a single string to the pool */
-JABBERD2_API void spool_escape(spool s, char *raw, int len); /* add and xml escape a single string to the pool */
-JABBERD2_API char *spools(pool_t p, ...); /* wrap all the spooler stuff in one function, the happy fun ball! */
+JABBERD2_API const char *spool_print(spool s); /* return a big string */
+JABBERD2_API void spool_add(spool s, const char *str); /* add a single string to the pool */
+JABBERD2_API void spool_escape(spool s, const char *raw, int len); /* add and xml escape a single string to the pool */
+JABBERD2_API const char *spools(pool_t p, ...); /* wrap all the spooler stuff in one function, the happy fun ball! */
 
 
 /* known namespace uri */
@@ -206,9 +206,9 @@ struct config_st
 /** a single element */
 struct config_elem_st
 {
-    char                **values;
+    const char          **values;
     int                 nvalues;
-    char                ***attrs;
+    const char          ***attrs;
 };
 
 JABBERD2_API config_t         config_new(void);
@@ -246,9 +246,9 @@ typedef struct access_st
 
 JABBERD2_API access_t    access_new(int order);
 JABBERD2_API void        access_free(access_t access);
-JABBERD2_API int         access_allow(access_t access, char *ip, char *mask);
-JABBERD2_API int         access_deny(access_t access, char *ip, char *mask);
-JABBERD2_API int         access_check(access_t access, char *ip);
+JABBERD2_API int         access_allow(access_t access, const char *ip, const char *mask);
+JABBERD2_API int         access_deny(access_t access, const char *ip, const char *mask);
+JABBERD2_API int         access_check(access_t access, const char *ip);
 
 
 /*
@@ -303,7 +303,7 @@ JABBERD2_API int         rate_check(rate_t rt);
 
 JABBERD2_API int         ser_string_get(char **dest, int *source, const char *buf, int len);
 JABBERD2_API int         ser_int_get(int *dest, int *source, const char *buf, int len);
-JABBERD2_API void        ser_string_set(char *source, int *dest, char **buf, int *len);
+JABBERD2_API void        ser_string_set(const char *source, int *dest, char **buf, int *len);
 JABBERD2_API void        ser_int_set(int source, int *dest, char **buf, int *len);
 
 /*
@@ -402,8 +402,8 @@ JABBERD2_API struct _stanza_error_st _stanza_errors[];
 
 
 /* hex conversion utils */
-JABBERD2_API void hex_from_raw(char *in, int inlen, char *out);
-JABBERD2_API int hex_to_raw(char *in, int inlen, char *out);
+JABBERD2_API void hex_from_raw(const char* in, int inlen, char* out);
+JABBERD2_API int hex_to_raw(const char *in, int inlen, char *out);
 
 
 /* xdata in a seperate file */

--- a/util/xdata.c
+++ b/util/xdata.c
@@ -23,7 +23,7 @@
 #include "util.h"
 
 /** creation */
-xdata_t xdata_new(xdata_type_t type, char *title, char *instructions) {
+xdata_t xdata_new(xdata_type_t type, const char *title, const char *instructions) {
     pool_t p;
     xdata_t xd;
 
@@ -46,7 +46,7 @@ xdata_t xdata_new(xdata_type_t type, char *title, char *instructions) {
 }
 
 /** new field */
-xdata_field_t xdata_field_new(xdata_t xd, xdata_field_type_t type, char *var, char *label, char *desc, int required) {
+xdata_field_t xdata_field_new(xdata_t xd, xdata_field_type_t type, const char *var, const char *label, const char *desc, int required) {
     xdata_field_t xdf;
 
     assert((int) (xd != NULL));
@@ -133,7 +133,7 @@ void xdata_add_item(xdata_t xd, xdata_item_t xdi) {
 }
 
 /** option insertion */
-static void xdata_option_new(xdata_field_t xdf, char *value, int lvalue, char *label, int llabel) {
+static void xdata_option_new(xdata_field_t xdf, const char *value, int lvalue, const char *label, int llabel) {
     xdata_option_t xdo;
 
     assert((int) (xdf != NULL));
@@ -157,7 +157,7 @@ static void xdata_option_new(xdata_field_t xdf, char *value, int lvalue, char *l
 }
 
 /** value insertion */
-void xdata_add_value(xdata_field_t xdf, char *value, int vlen) {
+void xdata_add_value(xdata_field_t xdf, const char *value, int vlen) {
     int first = 0;
 
     assert((int) (xdf != NULL));

--- a/util/xdata.h
+++ b/util/xdata.h
@@ -105,11 +105,11 @@ struct _xdata_item_st {
 };
 
 /** creation */
-JABBERD2_API xdata_t xdata_new(xdata_type_t type, char *title, char *instructions);
+JABBERD2_API xdata_t xdata_new(xdata_type_t type, const char *title, const char *instructions);
 JABBERD2_API xdata_t xdata_parse(nad_t nad, int root);
 
 /** new field */
-JABBERD2_API xdata_field_t xdata_field_new(xdata_t xd, xdata_field_type_t type, char *var, char *label, char *desc, int required);
+JABBERD2_API xdata_field_t xdata_field_new(xdata_t xd, xdata_field_type_t type, const char *var, const char *label, const char *desc, int required);
 
 /** new item */
 JABBERD2_API xdata_item_t xdata_item_new(xdata_t xd);
@@ -123,9 +123,9 @@ JABBERD2_API void xdata_add_field_item(xdata_item_t item, xdata_field_t xdf);
 JABBERD2_API void xdata_add_item(xdata_t xd, xdata_item_t xdi);
 
 /** option insertion */
-JABBERD2_API void xdata_add_option(xdata_field_t xdf, char *value, int lvalue, char *label, int llabel);
+JABBERD2_API void xdata_add_option(xdata_field_t xdf, const char *value, int lvalue, const char *label, int llabel);
 
 /** value insertion */
-JABBERD2_API void xdata_add_value(xdata_field_t xdf, char *value, int vlen);
+JABBERD2_API void xdata_add_value(xdata_field_t xdf, const char *value, int vlen);
 
 #endif


### PR DESCRIPTION
Add configure's  --enable-werror flag to enable paranoid '-Wall -Werror' flags

Fixed a bunch of compilation warnings:
- 'const char _'  VS 'char_'.
- unused local vars
- pointer-to-integer-cast

A few possible errors was discovered 
- possible integer overflow something like printf("%d", (int)pointer)
- error in _ar_sqlite_create_user: It could return success if actually failed

Note: some warnings are disabled to be fixed a bit later
