### PR TITLE
Get rid of warnings, part 2

### DIFF
--- a/c2s/pbx_commands.c
+++ b/c2s/pbx_commands.c
@@ -120,8 +120,8 @@ int _pbx_process_command(c2s_t c2s, const char *cmd)
 	jid_t jid;
 	int action = 0, len;
 	sess_t sess;
-	unsigned char hashbuf[44] = "PBX";
-	unsigned char *sesshash;
+	char hashbuf[44] = "PBX";
+	char *sesshash;
 
 	sesshash = hashbuf+3;
 

--- a/configure.ac
+++ b/configure.ac
@@ -937,7 +937,7 @@ fi
 AM_CONDITIONAL(ENABLE_TESTS, [test "x-$want_tests" = "x-yes"])
 
 AC_ARG_ENABLE([werror], AC_HELP_STRING([--enable-werror], [Treat all warnings as error]),
-              CFLAGS="-Wall -Werror -Wno-unused-result -Wno-pointer-sign -Wno-strict-overflow $CFLAGS")
+              CFLAGS="-Wall -Werror $CFLAGS")
 
 # Generate Makefiles
 AC_CONFIG_FILES([Doxyfile

--- a/router/filter.c
+++ b/router/filter.c
@@ -182,7 +182,7 @@ int filter_load(router_t r) {
 int filter_packet(router_t r, nad_t nad) {
     acl_t acl;
     int ato, afrom, error = 0;
-    unsigned char *cur, *to = NULL, *from = NULL;
+    char *cur, *to = NULL, *from = NULL;
 
     ato = nad_find_attr(nad, 1, -1, "to", NULL);
     afrom = nad_find_attr(nad, 1, -1, "from", NULL);

--- a/router/router.c
+++ b/router/router.c
@@ -1129,7 +1129,7 @@ int router_mio_callback(mio_t m, mio_action_t a, mio_fd_t fd, void *data, void *
 }
 
 
-int message_log(nad_t nad, router_t r, const unsigned char *msg_from, const unsigned char *msg_to)
+int message_log(nad_t nad, router_t r, const char *msg_from, const char *msg_to)
 {
     time_t t;
     char *time_pos;

--- a/router/router.h
+++ b/router/router.h
@@ -231,7 +231,7 @@ int     filter_load(router_t r);
 void    filter_unload(router_t r);
 int     filter_packet(router_t r, nad_t nad);
 
-int     message_log(nad_t nad, router_t r, const unsigned char *msg_from, const unsigned char *msg_to);
+int     message_log(nad_t nad, router_t r, const char *msg_from, const char *msg_to);
 
 void routes_free(routes_t routes);
 

--- a/sm/mod_privacy.c
+++ b/sm/mod_privacy.c
@@ -320,7 +320,7 @@ static int _privacy_action(user_t user, zebra_list_t zlist, jid_t jid, pkt_type_
     zebra_item_t scan;
     int match, i;
     item_t ritem;
-    unsigned char domres[2048];
+    char domres[2048];
 
     log_debug(ZONE, "running match on list %s for %s (packet type 0x%x) (%s)", zlist->name, jid_full(jid), ptype, in ? "incoming" : "outgoing");
 

--- a/sm/mod_status.c
+++ b/sm/mod_status.c
@@ -34,7 +34,7 @@ typedef struct _status_st {
     const char *resource;
 } *status_t;
 
-static void _status_os_replace(storage_t st, const unsigned char *jid, char *status, char *show, time_t *lastlogin, time_t *lastlogout, nad_t nad) {
+static void _status_os_replace(storage_t st, const char *jid, char *status, char *show, time_t *lastlogin, time_t *lastlogout, nad_t nad) {
     os_t os = os_new();
     os_object_t o = os_object_new(os);
     os_object_put(o, "status", status, os_type_STRING);
@@ -46,7 +46,7 @@ static void _status_os_replace(storage_t st, const unsigned char *jid, char *sta
     os_free(os);
 }
 
-static void _status_store(storage_t st, const unsigned char *jid, pkt_t pkt, time_t *lastlogin, time_t *lastlogout) {
+static void _status_store(storage_t st, const char *jid, pkt_t pkt, time_t *lastlogin, time_t *lastlogout) {
     char *show;
     int show_free = 0;
 

--- a/sm/sess.c
+++ b/sm/sess.c
@@ -105,7 +105,7 @@ sess_t sess_start(sm_t sm, jid_t jid) {
     user_t user;
     sess_t sess, scan;
     sha1_state_t sha1;
-    char hash[20];
+    unsigned char hash[20];
     int replaced = 0;
 
     log_debug(ZONE, "session requested for %s", jid_full(jid));

--- a/storage/authreg_pgsql.c
+++ b/storage/authreg_pgsql.c
@@ -54,10 +54,6 @@ enum pgsql_pws_crypt {
 #endif
 };
 
-#ifdef HAVE_CRYPT
-static char salter[] = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ./";
-#endif
-
 typedef struct pgsqlcontext_st {
   PGconn * conn;
   const char * sql_create;
@@ -244,7 +240,6 @@ static int _ar_pgsql_dbcheck_password(authreg_t ar, const char *username, const 
 static int _ar_pgsql_check_password(authreg_t ar, const char *username, const char *realm, char password[257])
 {
     pgsqlcontext_t ctx = (pgsqlcontext_t) ar->private;
-    PGconn *conn = ctx->conn;
     char db_pw_value[257];
 #ifdef HAVE_CRYPT
     char *crypted_pw;

--- a/storage/storage_sqlite.c
+++ b/storage/storage_sqlite.c
@@ -136,7 +136,7 @@ static char *_st_sqlite_convert_filter (st_driver_t drv, const char *owner,
 					const char *filter) {
 
     char *buf = NULL;
-    unsigned int buflen = 0, nbuf = 0;
+    int buflen = 0, nbuf = 0;
     st_filter_t f;
 
 
@@ -481,7 +481,7 @@ static st_ret_t _st_sqlite_get (st_driver_t drv, const char *type,
 	    } else if (coltype == SQLITE3_TEXT) {
 		ot = os_type_STRING;
 
-		val = sqlite3_column_text (stmt, i);
+		val = (const char*)sqlite3_column_text (stmt, i);
 		os_object_put (o, colname, val, ot);
 
 	    } else {

--- a/sx/compress.c
+++ b/sx/compress.c
@@ -157,14 +157,14 @@ static int _sx_compress_wio(sx_t s, sx_plugin_t p, sx_buf_t buf) {
     /* compress the data */
     if(sc->wbuf->len > 0) {
         sc->wstrm.avail_in = sc->wbuf->len;
-        sc->wstrm.next_in = sc->wbuf->data;
+        sc->wstrm.next_in = (Bytef*)sc->wbuf->data;
         /* deflate() on write buffer until there is data to compress */
         do {
             /* make place for deflated data */
             _sx_buffer_alloc_margin(buf, 0, sc->wbuf->len + SX_COMPRESS_CHUNK);
 
                 sc->wstrm.avail_out = sc->wbuf->len + SX_COMPRESS_CHUNK;
-            sc->wstrm.next_out = buf->data + buf->len;
+            sc->wstrm.next_out = (Bytef*)(buf->data + buf->len);
 
             ret = deflate(&(sc->wstrm), Z_SYNC_FLUSH);
             assert(ret != Z_STREAM_ERROR);
@@ -185,7 +185,7 @@ static int _sx_compress_wio(sx_t s, sx_plugin_t p, sx_buf_t buf) {
         }
 
         sc->wbuf->len = sc->wstrm.avail_in;
-        sc->wbuf->data = sc->wstrm.next_in;
+        sc->wbuf->data = (char*)sc->wstrm.next_in;
     }
 
     _sx_debug(ZONE, "passing %d bytes from zlib write buffer", buf->len);
@@ -218,14 +218,14 @@ static int _sx_compress_rio(sx_t s, sx_plugin_t p, sx_buf_t buf) {
     /* decompress the data */
     if(sc->rbuf->len > 0) {
         sc->rstrm.avail_in = sc->rbuf->len;
-        sc->rstrm.next_in = sc->rbuf->data;
+        sc->rstrm.next_in = (Bytef*)sc->rbuf->data;
         /* run inflate() on read buffer while able to fill the output buffer */
         do {
             /* make place for inflated data */
             _sx_buffer_alloc_margin(buf, 0, SX_COMPRESS_CHUNK);
 
             sc->rstrm.avail_out = SX_COMPRESS_CHUNK;
-            sc->rstrm.next_out = buf->data + buf->len;
+            sc->rstrm.next_out = (Bytef*)(buf->data + buf->len);
 
             ret = inflate(&(sc->rstrm), Z_SYNC_FLUSH);
             assert(ret != Z_STREAM_ERROR);
@@ -248,7 +248,7 @@ static int _sx_compress_rio(sx_t s, sx_plugin_t p, sx_buf_t buf) {
         } while (sc->rstrm.avail_out == 0);
 
         sc->rbuf->len = sc->rstrm.avail_in;
-        sc->rbuf->data = sc->rstrm.next_in;
+        sc->rbuf->data = (char*)sc->rstrm.next_in;
     }
 
     _sx_debug(ZONE, "passing %d bytes from zlib read buffer", buf->len);

--- a/sx/sx.h
+++ b/sx/sx.h
@@ -111,9 +111,9 @@ typedef void (*_sx_notify_t)(sx_t s, void *arg);
 /** utility: buffer */
 typedef struct _sx_buf_st *sx_buf_t;
 struct _sx_buf_st {
-    unsigned char           *data;     /* pointer to buffer's data */
-    unsigned int            len;       /* length of buffer's data */
-    unsigned char           *heap;     /* beginning of malloc() block containing data, if non-NULL */
+    char           *data;     /* pointer to buffer's data */
+    unsigned int   len;       /* length of buffer's data */
+    char           *heap;     /* beginning of malloc() block containing data, if non-NULL */
 
     /* function to call when this buffer gets written */
     _sx_notify_t            notify;

--- a/util/hex.c
+++ b/util/hex.c
@@ -23,7 +23,7 @@
 #include "util.h"
 
 /** turn raw into hex - out must be (inlen*2)+1 */
-void hex_from_raw(const char *in, int inlen, char *out) {
+void hex_from_raw(const unsigned char *in, int inlen, char *out) {
     int i, h, l;
 
     for(i = 0; i < inlen; i++) {

--- a/util/jid.c
+++ b/util/jid.c
@@ -22,7 +22,7 @@
 #include <stringprep.h>
 
 /** Forward declaration **/
-static jid_t jid_reset_components_internal(jid_t jid, const unsigned char *node, const unsigned char *domain, const unsigned char *resource, int prepare);
+static jid_t jid_reset_components_internal(jid_t jid, const char *node, const char *domain, const char *resource, int prepare);
 
 /** do stringprep on the pieces */
 static int jid_prep_pieces(char *node, char *domain, char *resource) {
@@ -78,7 +78,7 @@ int jid_prep(jid_t jid)
 }
 
 /** make a new jid */
-jid_t jid_new(const unsigned char *id, int len) {
+jid_t jid_new(const char *id, int len) {
     jid_t jid, ret;
 
     jid = malloc(sizeof(struct jid_st));
@@ -105,13 +105,13 @@ void jid_static(jid_t jid, jid_static_buf *buf)
     memset(jid, 0, sizeof(*jid));
 
     /* set buffer */
-    jid->jid_data = (unsigned char *)buf;
+    jid->jid_data = (char *)buf;
 }
 
 
 /** build a jid from an id */
-jid_t jid_reset(jid_t jid, const unsigned char *id, int len) {
-    unsigned char *myid, *cur, *olddata=NULL;
+jid_t jid_reset(jid_t jid, const char *id, int len) {
+    char *myid, *cur, *olddata=NULL;
 
     assert((int) (jid != NULL));
 
@@ -196,8 +196,8 @@ jid_t jid_reset(jid_t jid, const unsigned char *id, int len) {
 }
 
 /** build a jid from components - internal version */
-static jid_t jid_reset_components_internal(jid_t jid, const unsigned char *node, const unsigned char *domain, const unsigned char *resource, int prepare) {
-    unsigned char *olddata=NULL;
+static jid_t jid_reset_components_internal(jid_t jid, const char *node, const char *domain, const char *resource, int prepare) {
+    char *olddata=NULL;
     int node_l,domain_l,resource_l;
     int dataStatic;
     jid_static_buf staticTmpBuf;
@@ -269,16 +269,16 @@ static jid_t jid_reset_components_internal(jid_t jid, const unsigned char *node,
         memcpy(jid->jid_data,staticTmpBuf,node_l+domain_l+resource_l+3); /* Copy data from tmp buf to original buffer */
 
         /* Relocate pointers */
-        jid->node = olddata+(jid->node-(unsigned char *)staticTmpBuf);
-        jid->domain = olddata+(jid->domain-(unsigned char *)staticTmpBuf);
-        jid->resource = olddata+(jid->resource-(unsigned char *)staticTmpBuf);
+        jid->node = olddata+(jid->node-(char *)staticTmpBuf);
+        jid->domain = olddata+(jid->domain-(char *)staticTmpBuf);
+        jid->resource = olddata+(jid->resource-(char *)staticTmpBuf);
     }
 
     return jid;
 }
 
 /** build a jid from components */
-jid_t jid_reset_components(jid_t jid, const unsigned char *node, const unsigned char *domain, const unsigned char *resource) {
+jid_t jid_reset_components(jid_t jid, const char *node, const char *domain, const char *resource) {
     return jid_reset_components_internal(jid, node, domain, resource, 1);
 }
 
@@ -305,7 +305,7 @@ void jid_expand(jid_t jid)
 
     if(*jid->domain == '\0') {
       /* empty */
-      jid->_full = (unsigned char*) realloc(jid->_full, 1);
+      jid->_full = (char*) realloc(jid->_full, 1);
       jid->_full[0] = 0;
       return;
     }
@@ -316,19 +316,19 @@ void jid_expand(jid_t jid)
 
     if(nlen == 0) {
         ulen = dlen+1;
-        jid->_user = (unsigned char*) realloc(jid->_user, ulen);
+        jid->_user = (char*) realloc(jid->_user, ulen);
         strcpy(jid->_user, jid->domain);
     } else {
         ulen = nlen+1+dlen+1;
-        jid->_user = (unsigned char*) realloc(jid->_user, ulen);
+        jid->_user = (char*) realloc(jid->_user, ulen);
         snprintf(jid->_user, ulen, "%s@%s", jid->node, jid->domain);
     }
 
     if(rlen == 0) {
-        jid->_full = (unsigned char*) realloc(jid->_full, ulen);
+        jid->_full = (char*) realloc(jid->_full, ulen);
         strcpy(jid->_full, jid->_user);
     } else {
-        jid->_full = (unsigned char*) realloc(jid->_full, ulen+1+rlen);
+        jid->_full = (char*) realloc(jid->_full, ulen+1+rlen);
         snprintf(jid->_full, ulen+1+rlen, "%s/%s", jid->_user, jid->resource);
     }
 
@@ -336,7 +336,7 @@ void jid_expand(jid_t jid)
 }
 
 /** expand and return the user */
-const unsigned char *jid_user(jid_t jid)
+const char *jid_user(jid_t jid)
 {
     jid_expand(jid);
 
@@ -344,7 +344,7 @@ const unsigned char *jid_user(jid_t jid)
 }
 
 /** expand and return the full */
-const unsigned char *jid_full(jid_t jid)
+const char *jid_full(jid_t jid)
 {
     jid_expand(jid);
 

--- a/util/jid.h
+++ b/util/jid.h
@@ -41,24 +41,24 @@
 
 typedef struct jid_st {
     /* basic components of the jid */
-    unsigned char   *node;
-    unsigned char   *domain;
-    unsigned char   *resource;
+    char   *node;
+    char   *domain;
+    char   *resource;
 
     /* Points to jid broken with \0s into componets. node/domain/resource point
      * into this string (or to statically allocated empty string, if they are
      * empty) */
-    unsigned char   *jid_data;
+    char   *jid_data;
     /* Valid only when jid_data != NULL. When = 0, jid_data is statically
      * allocated. Otherwise it tells length of the allocated data. Used to
      * implement jid_dup() */
     size_t          jid_data_len;
 
     /* the "user" part of the jid (sans resource) */
-    unsigned char   *_user;
+    char   *_user;
 
     /* the complete jid */
-    unsigned char   *_full;
+    char   *_full;
 
     /* application should set to 1 if user/full need regenerating */
     int             dirty;
@@ -77,15 +77,15 @@ typedef enum {
 typedef char jid_static_buf[3*1025];
 
 /** make a new jid, and call jid_reset() to populate it */
-JABBERD2_API jid_t               jid_new(const unsigned char *id, int len);
+JABBERD2_API jid_t               jid_new(const char *id, int len);
 
 /** Make jid to use static buffer (jid data won't be allocated dynamically, but
  * given buffer will be always used. */
 JABBERD2_API void                jid_static(jid_t jid, jid_static_buf *buf);
 
 /** clear and populate the jid with the given id. if id == NULL, just clears the jid to 0 */
-JABBERD2_API jid_t               jid_reset(jid_t jid, const unsigned char *id, int len);
-JABBERD2_API jid_t               jid_reset_components(jid_t jid, const unsigned char *node, const unsigned char *domain, const unsigned char *resource);
+JABBERD2_API jid_t               jid_reset(jid_t jid, const char *id, int len);
+JABBERD2_API jid_t               jid_reset_components(jid_t jid, const char *node, const char *domain, const char *resource);
 
 /** free the jid */
 JABBERD2_API void                jid_free(jid_t jid);
@@ -101,8 +101,8 @@ JABBERD2_API void                jid_expand(jid_t jid);
 
 /** return the user or full jid. these call jid_expand to make sure the user and
  * full jid are up to date */
-JABBERD2_API const unsigned char *jid_user(jid_t jid);
-JABBERD2_API const unsigned char *jid_full(jid_t jid);
+JABBERD2_API const char *jid_user(jid_t jid);
+JABBERD2_API const char *jid_full(jid_t jid);
 
 /** compare two user or full jids. these call jid_expand, then strcmp. returns
  * 0 if they're the same, < 0 if a < b, > 0 if a > b */

--- a/util/util.h
+++ b/util/util.h
@@ -402,7 +402,7 @@ JABBERD2_API struct _stanza_error_st _stanza_errors[];
 
 
 /* hex conversion utils */
-JABBERD2_API void hex_from_raw(const char* in, int inlen, char* out);
+JABBERD2_API void hex_from_raw(const unsigned char* in, int inlen, char* out);
 JABBERD2_API int hex_to_raw(const char *in, int inlen, char *out);
 
 


### PR DESCRIPTION
Fix new 'unused variable' warnings in authreg_pgsql.c
All string data are stored referenced as '[const] char *' but never as '[const] unsigned char *'
Binary data are stored as 'unsigned char *' but never as 'char *'
Some explicit type cast added for external lib's calls (zlib, OpenSSL and sqlite3)
