### PR TITLE
Use AM_CPPFLAGS instead of long-obsoleted INCLUDES.

### DIFF
--- a/c2s/Makefile.am
+++ b/c2s/Makefile.am
@@ -1,5 +1,5 @@
 LIBTOOL += --quiet
-INCLUDES = -I@top_srcdir@
+AM_CPPFLAGS = -I@top_srcdir@
 
 bin_PROGRAMS = c2s
 

--- a/mio/Makefile.am
+++ b/mio/Makefile.am
@@ -1,5 +1,5 @@
 LIBTOOL += --quiet
-INCLUDES = -I@top_srcdir@
+AM_CPPFLAGS = -I@top_srcdir@
 
 noinst_LTLIBRARIES = libmio.la
 

--- a/router/Makefile.am
+++ b/router/Makefile.am
@@ -1,4 +1,4 @@
-INCLUDES = -DCONFIG_DIR=\"$(sysconfdir)\" -I@top_srcdir@
+AM_CPPFLAGS = -DCONFIG_DIR=\"$(sysconfdir)\" -I@top_srcdir@
 
 LIBTOOL += --quiet
 

--- a/s2s/Makefile.am
+++ b/s2s/Makefile.am
@@ -1,4 +1,4 @@
-INCLUDES = -DCONFIG_DIR=\"$(sysconfdir)\" -I@top_srcdir@
+AM_CPPFLAGS = -DCONFIG_DIR=\"$(sysconfdir)\" -I@top_srcdir@
 
 LIBTOOL += --quiet
 

--- a/sm/Makefile.am
+++ b/sm/Makefile.am
@@ -1,5 +1,5 @@
 LIBTOOL += --quiet
-INCLUDES = -I@top_srcdir@
+AM_CPPFLAGS = -I@top_srcdir@
 
 bin_PROGRAMS = sm
 

--- a/storage/Makefile.am
+++ b/storage/Makefile.am
@@ -1,6 +1,6 @@
 EXTRA_DIST = authreg_ntlogon.c authreg_sspi.c
 
-INCLUDES = -I$(top_srcdir)/c2s -I@top_srcdir@
+AM_CPPFLAGS = -I$(top_srcdir)/c2s -I@top_srcdir@
 
 LIBTOOL += --quiet
 

--- a/sx/Makefile.am
+++ b/sx/Makefile.am
@@ -1,5 +1,5 @@
 LIBTOOL += --quiet
-INCLUDES = -I@top_srcdir@
+AM_CPPFLAGS = -I@top_srcdir@
 
 noinst_LTLIBRARIES = libsx.la
 noinst_HEADERS = plugins.h sasl.h sx.h

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,5 +1,5 @@
 LIBTOOL += --quiet
-INCLUDES = -I@top_srcdir@
+AM_CPPFLAGS = -I@top_srcdir@
 
 EXTRA_DIST = *.xml subdir
 

--- a/util/Makefile.am
+++ b/util/Makefile.am
@@ -1,5 +1,5 @@
 LIBTOOL += --quiet
-INCLUDES = -I@top_srcdir@
+AM_CPPFLAGS = -I@top_srcdir@
 
 noinst_LTLIBRARIES = libutil.la
 


### PR DESCRIPTION
Automake 1.14 has removed support for the INCLUDES directive which has been marked as obsolete in documentation for a long time.  From automake NEWS:
- Support for the long-obsolete $(INCLUDES) variable has been finally
  removed, in favour of the modern equivalent $(AM_CPPFLAGS).
