### PR TITLE
Required GSASL >=1.1 (released in 2009) to avoid gsasl struct introspection

### DIFF
--- a/README
+++ b/README
@@ -10,9 +10,8 @@ Required packages:
 
  - expat - XML parsing libraries
      http://expat.sourceforge.net/
- - GnuSASL (0.2.27 or higher) - Simple Authentication and Security Layer library
+ - GnuSASL (1.1 or higher) - Simple Authentication and Security Layer library
      http://www.gnu.org/software/gsasl/
-     (please see contrib/ subdir for an important patch)
  - UDNS - asynchronous DNS resolver library
      http://www.corpit.ru/mjt/udns.html
 


### PR DESCRIPTION
Is bumping the gsasl required version to 1.1 something you would consider?  You can get rid of a lot of code that does not look very robust (it duplicates some of gsasl's internal structs) that way.  GNU SASL version 1.1 was released in March 2009 so it should be fairly common by now, I would hope.  GSASL since version 1.1 only supports qop=auth, and the (broken) integrity/confidentiality layers of DIGEST-MD5 are not supported any more.  So the old code to force qop=auth is not needed.  If you want, we could add a build-time config check for a recent enough gsasl to make sure people don't build jabberd2 with old gsasl.

Btw, I'm the gsasl author, and I'm setting up a jabberd2 server for some XMPP/SASL testing that may result in some more SASL related code back to you.  I'm now just going through to make sure jabberd2 is using gsasl in the best way.
