### PR TITLE
Hashed password algorithm change

### DIFF
--- a/storage/authreg_mysql.c
+++ b/storage/authreg_mysql.c
@@ -252,7 +252,7 @@ static int _ar_mysql_set_password(authreg_t ar, const char *username, const char
        srand(time(0));
        for(i=0; i<22; i++)
                salt[16+i] = salter[rand()%64];
-       salt[39] = '\0';
+       salt[38] = '\0';
        strcpy(password, crypt(password, salt));
     }
 #endif


### PR DESCRIPTION
Changed default password hashing algorithm from MD5 to SHA512 with 50000 rounds and a 22 character salt, to improve security against offline password cracking attacks.
