### PR TITLE
Fix off-source build

### DIFF
--- a/c2s/Makefile.am
+++ b/c2s/Makefile.am
@@ -1,10 +1,9 @@
 LIBTOOL += --quiet
-AM_CPPFLAGS = -I@top_srcdir@
 
 bin_PROGRAMS = c2s
 
 c2s_SOURCES = authreg.c bind.c c2s.c main.c sm.c pbx.c pbx_commands.c address.c
-c2s_CPPFLAGS = -DCONFIG_DIR=\"$(sysconfdir)\" -DLIBRARY_DIR=\"$(pkglibdir)\"
+c2s_CPPFLAGS = -DCONFIG_DIR=\"$(sysconfdir)\" -DLIBRARY_DIR=\"$(pkglibdir)\" -I@top_srcdir@
 c2s_LDFLAGS = -export-dynamic
 
 noinst_HEADERS = c2s.h

--- a/sm/Makefile.am
+++ b/sm/Makefile.am
@@ -1,5 +1,4 @@
 LIBTOOL += --quiet
-AM_CPPFLAGS = -I@top_srcdir@
 
 bin_PROGRAMS = sm
 
@@ -26,7 +25,7 @@ pkglib_LTLIBRARIES = mod_active.la \
                   mod_status.la \
                   mod_template-roster.la \
                   mod_vacation.la \
-                  mod_validate.la 
+                  mod_validate.la
 
 noinst_HEADERS = sm.h
 
@@ -41,7 +40,7 @@ sm_SOURCES = aci.c \
              sm.c \
              user.c
 
-sm_CPPFLAGS = -DCONFIG_DIR=\"$(sysconfdir)\" -DLIBRARY_DIR=\"$(pkglibdir)\"
+sm_CPPFLAGS = -DCONFIG_DIR=\"$(sysconfdir)\" -DLIBRARY_DIR=\"$(pkglibdir)\" -I@top_srcdir@
 sm_LDFLAGS = -export-dynamic
 sm_LDADD = $(top_builddir)/sx/libsx.la \
            $(top_builddir)/mio/libmio.la \


### PR DESCRIPTION
off-source build is broken in 5ef0f343d219c9a9c3f7425251e06e97176411d2
by replacing INCLUDES with AM_CPPFLAGS

http://www.gnu.org/software/automake/manual/html_node/Program-Variables.html

> AM_CPPFLAGS is ignored in preference to a per-executable (or per-library) _CPPFLAGS variable
> if it is defined.
