### PR TITLE
Use ${id}.pid as PID filename instead of fixed name

### DIFF
--- a/etc/c2s.xml.dist.in
+++ b/etc/c2s.xml.dist.in
@@ -5,7 +5,7 @@
 
   <!-- The process ID file. Comment this out if you don't need to know
        the process ID from outside the process (eg for control scripts) -->
-  <pidfile>@localstatedir@/@package@/pid/c2s.pid</pidfile>
+  <pidfile>@localstatedir@/@package@/pid/${id}.pid</pidfile>
 
   <!-- Router connection configuration -->
   <router>

--- a/etc/router.xml.dist.in
+++ b/etc/router.xml.dist.in
@@ -5,7 +5,7 @@
 
   <!-- The process ID file. Comment this out if you don't need to know
        the process ID from outside the process (eg for control scripts) -->
-  <pidfile>@localstatedir@/@package@/pid/router.pid</pidfile>
+  <pidfile>@localstatedir@/@package@/pid/${id}.pid</pidfile>
 
   <!-- Log configuration - type is "syslog", "file" or "stdout" -->
   <log type='syslog'>

--- a/etc/s2s.xml.dist.in
+++ b/etc/s2s.xml.dist.in
@@ -5,7 +5,7 @@
 
   <!-- The process ID file. Comment this out if you don't need to know
        the process ID from outside the process (eg for control scripts) -->
-  <pidfile>@localstatedir@/@package@/pid/s2s.pid</pidfile>
+  <pidfile>@localstatedir@/@package@/pid/${id}.pid</pidfile>
 
   <!-- Router connection configuration -->
   <router>

--- a/etc/sm.xml.dist.in
+++ b/etc/sm.xml.dist.in
@@ -5,7 +5,7 @@
 
   <!-- The process ID file. Comment this out if you don't need to know
        the process ID from outside the process (eg for control scripts) -->
-  <pidfile>@localstatedir@/@package@/pid/sm.pid</pidfile>
+  <pidfile>@localstatedir@/@package@/pid/${id}.pid</pidfile>
 
   <!-- Router connection configuration -->
   <router>


### PR DESCRIPTION
This change simplifies multiple component configuration: you don't need to change  PID file name once the configuration file is copied. Just update component ID.
