### PR TITLE
sess_end for authreg to cleanup private data

### DIFF
--- a/c2s/c2s.c
+++ b/c2s/c2s.c
@@ -572,6 +572,12 @@ static int _c2s_client_mio_callback(mio_t m, mio_action_t a, mio_fd_t fd, void *
                 for(bres = sess->resources; bres != NULL; bres = bres->next)
                     sm_end(sess, bres);
 
+            /* call the session end callback to allow for authreg
+             * module to cleanup private data */
+            if(sess->c2s->ar->sess_end != NULL)
+                (sess->c2s->ar->sess_end)(sess->c2s->ar, sess);
+
+            /* force free authreg_private if pointer is still set */
             if (sess->authreg_private != NULL) {
                 free(sess->authreg_private);
                 sess->authreg_private = NULL;

--- a/c2s/c2s.h
+++ b/c2s/c2s.h
@@ -340,6 +340,10 @@ struct authreg_st
     int         (*create_user)(authreg_t ar, sess_t sess, const char *username, const char *realm);
     int         (*delete_user)(authreg_t ar, sess_t sess, const char *username, const char *realm);
 
+    /** called prior to session being closed, to cleanup session specific private data */
+    void        (*sess_end)(authreg_t ar, sess_t sess);
+
+    /** called prior to authreg shutdown */
     void        (*free)(authreg_t ar);
 
     /* Additions at the end - to preserve offsets for existing modules */


### PR DESCRIPTION
Given that we now allow for authreg providers to store private data
in sess_st and it is an opaque object for c2s, we now call back
into authreg via sess_end to allow it to cleanup its internal data.
