### PR TITLE
Invalid INTEGER/BOOLEAN values are saved to database storages in x86_64.

### DIFF
--- a/storage/storage_db.c
+++ b/storage/storage_db.c
@@ -156,6 +156,11 @@ static void _st_db_object_serialise(os_object_t o, char **buf, int *len) {
 
     if(os_object_iter_first(o))
         do {
+            /* For os_type_BOOLEAN and os_type_INTEGER, sizeof(int) bytes
+               are stored in val, which might be less than sizeof(void *).
+               Therefore, the difference is garbage unless cleared first.
+             */
+            val = NULL;
             os_object_iter_get(o, &key, &val, &ot);
             
             log_debug(ZONE, "serialising key %s", key);
@@ -165,11 +170,11 @@ static void _st_db_object_serialise(os_object_t o, char **buf, int *len) {
 
             switch(ot) {
                 case os_type_BOOLEAN:
-                    ser_int_set(((int) (long) val) != 0, &cur, buf, len);
+                    ser_int_set(((int)val) != 0, &cur, buf, len);
                     break;
 
                 case os_type_INTEGER:
-                    ser_int_set((int) (long) val, &cur, buf, len);
+                    ser_int_set((int)val, &cur, buf, len);
                     break;
 
                 case os_type_STRING:

--- a/storage/storage_mysql.c
+++ b/storage/storage_mysql.c
@@ -194,16 +194,21 @@ static st_ret_t _st_mysql_put_guts(st_driver_t drv, const char *type, const char
             o = os_iter_object(os);
             if(os_object_iter_first(o))
                 do {
+                    /* For os_type_BOOLEAN and os_type_INTEGER, sizeof(int) bytes
+                       are stored in val, which might be less than sizeof(void *).
+                       Therefore, the difference is garbage unless cleared first.
+                     */
+                    val = NULL;
                     os_object_iter_get(o, &key, &val, &ot);
         
                     switch(ot) {
                         case os_type_BOOLEAN:
-                            cval = val ? strdup("1") : strdup("0");
+                            cval = ((int)val != 0) ? strdup("1") : strdup("0");
                             break;
         
                         case os_type_INTEGER:
                             cval = (char *) malloc(sizeof(char) * 20);
-                            sprintf(cval, "%ld", (long int) val);
+                            sprintf(cval, "%d", (int) val);
                             break;
         
                         case os_type_STRING:
@@ -218,7 +223,7 @@ static st_ret_t _st_mysql_put_guts(st_driver_t drv, const char *type, const char
                             strncpy(cval, "NAD", 3);
                             break;
 
-			case os_type_UNKNOWN:
+                        case os_type_UNKNOWN:
                             break;
                     }
         

--- a/storage/storage_oracle.c
+++ b/storage/storage_oracle.c
@@ -388,12 +388,17 @@ static st_ret_t _st_oracle_put_guts(st_driver_t drv, const char *type, const cha
       {
         do 
         {
+          /* For os_type_BOOLEAN and os_type_INTEGER, sizeof(int) bytes
+             are stored in val, which might be less than sizeof(dvoid *).
+             Therefore, the difference is garbage unless cleared first.
+           */
+          val = NULL;
           os_object_iter_get(o, &key, &val, &ot);
 
           switch(ot) 
           {
             case os_type_BOOLEAN:
-              cval = val ? strdup("1") : strdup("0");
+              cval = ((int)val != 0) ? strdup("1") : strdup("0");
               vlen = 1;
               break;
 

--- a/storage/storage_pgsql.c
+++ b/storage/storage_pgsql.c
@@ -194,16 +194,22 @@ static st_ret_t _st_pgsql_put_guts(st_driver_t drv, const char *type, const char
             o = os_iter_object(os);
             if(os_object_iter_first(o))
                 do {
+
+                    /* For os_type_BOOLEAN and os_type_INTEGER, sizeof(int) bytes
+                       are stored in val, which might be less than sizeof(void *).
+                       Therefore, the difference is garbage unless cleared first.
+                     */
+                    val = NULL;
                     os_object_iter_get(o, &key, &val, &ot);
 
                     switch(ot) {
                         case os_type_BOOLEAN:
-                            cval = val ? strdup("t") : strdup("f");
+                            cval = ((int)val != 0) ? strdup("t") : strdup("f");
                             break;
 
                         case os_type_INTEGER:
                             cval = (char *) malloc(sizeof(char) * 20);
-                            sprintf(cval, "%ld", (int) (intptr_t) val);
+                            sprintf(cval, "%d", (int)val);
                             break;
 
                         case os_type_STRING:

--- a/storage/storage_sqlite.c
+++ b/storage/storage_sqlite.c
@@ -292,15 +292,20 @@ static st_ret_t _st_sqlite_put_guts (st_driver_t drv, const char *type,
 	    o = os_iter_object (os);
 	    if (os_object_iter_first(o))
 		do {
+            /* For os_type_BOOLEAN and os_type_INTEGER, sizeof(int) bytes
+               are stored in val, which might be less than sizeof(void *).
+               Therefore, the difference is garbage unless cleared first.
+             */
+            val = NULL;
 		    os_object_iter_get (o, &key, &val, &ot);
 
 		    switch(ot) {
 		     case os_type_BOOLEAN:
-		      sqlite3_bind_int (stmt, i + 2, val ? 1 : 0);
+		      sqlite3_bind_int (stmt, i + 2, ((int)val != 0) ? 1 : 0);
 		      break;
 
 		     case os_type_INTEGER:
-		      sqlite3_bind_int (stmt, i + 2, (long)val); // HACK ugly hack for pointer-to-int-cast
+		      sqlite3_bind_int (stmt, i + 2, (int)val);
 		      break;
 
 		     case os_type_STRING:


### PR DESCRIPTION
Discussion can be found at: https://github.com/jabberd2/jabberd2/issues/67
