### PR TITLE
Zero fill realloc'd memory for _nad_realloc.

### DIFF
--- a/util/nad.c
+++ b/util/nad.c
@@ -80,8 +80,11 @@ static int _nad_realloc(void **oblocks, int len)
     /* round up to standard block sizes */
     nlen = (((len-1)/BLOCKSIZE)+1)*BLOCKSIZE;
 
-    /* keep trying till we get it */
+    /* reallocate and zero out the new memory */
     *oblocks = realloc(*oblocks, nlen);
+    if (nlen > len)
+        memset(*oblocks + len, 0, nlen - len);
+
     return nlen;
 }
 


### PR DESCRIPTION
Several pieces of code in nad.c call on NAD_SAFE to realloc memory and use the memory without initializing it. One particular example is in nad_insert_nad() where phantom namespaces were being added because the code checked for lprefix for element namespaces and reading in values from uninitialized memory returned from realloc. This change is a bit conservative but a safer choice to avoid future silent corruptions.
