### PR TITLE
Set nss[].lprefix to 0 when prefix is NULL in nad_(add/append)_namepsace

### DIFF
--- a/util/nad.c
+++ b/util/nad.c
@@ -758,7 +758,10 @@ int nad_add_namespace(nad_t nad, const char *uri, const char *prefix)
         nad->nss[ns].iprefix = _nad_cdata(nad, prefix, nad->nss[ns].lprefix);
     }
     else
+    {
+        nad->nss[ns].lprefix = 0;
         nad->nss[ns].iprefix = -1;
+    }
 
     return ns;
 }
@@ -789,7 +792,8 @@ int nad_append_namespace(nad_t nad, int elem, const char *uri, const char *prefi
         nad->nss[ns].lprefix = strlen(prefix);
         nad->nss[ns].iprefix = _nad_cdata(nad, prefix, nad->nss[ns].lprefix);
     }
-    else {
+    else
+    {
         nad->nss[ns].lprefix = 0;
         nad->nss[ns].iprefix = -1;
     }


### PR DESCRIPTION
Code in nad.c, specifically nad_insert_nad(), checks lprefix to test if
an element needs to be prefixed. nad_append_namespace() called from
nad_parse() doesn't explicitly set lprefix to zero when prefix is NULL.
Since memory in nad.c is allocated via realloc(), newly allocated memory
is un-initialized and depending on your luck can be either 0 or non-zero
which can lead to phantom namespace prefixes being added.
