### PR TITLE
Rewrite TLS ephemeral key + cipher handling

### DIFF
--- a/c2s/c2s.h
+++ b/c2s/c2s.h
@@ -140,12 +140,14 @@ struct host_st {
     /** require starttls */
     int                 host_require_starttls;
 
+    /** list of TLS ciphers */
+    const char          *host_ciphers;
+
     /** registration */
     int                 ar_register_enable;
     const char          *ar_register_instructions;
     const char          *ar_register_oob;
     int                 ar_register_password;
-
 };
 
 struct c2s_st {
@@ -160,6 +162,7 @@ struct c2s_st {
     const char          *router_pemfile;
     const char          *router_cachain;
     const char          *router_private_key_password;
+    const char          *router_ciphers;
 
     /** mio context */
     mio_t               mio;
@@ -223,6 +226,9 @@ struct c2s_st {
 
     /** verify-mode  */
     int                 local_verify_mode;
+
+    /** list of TLS ciphers */
+    const char          *local_ciphers;
 
     /** http forwarding URL */
     const char          *http_forward;

--- a/c2s/main.c
+++ b/c2s/main.c
@@ -109,6 +109,7 @@ static void _c2s_config_expand(c2s_t c2s)
     c2s->router_cachain = config_get_one(c2s->config, "router.cachain", 0);
 
     c2s->router_private_key_password = config_get_one(c2s->config, "router.private_key_password", 0);
+    c2s->router_ciphers = config_get_one(c2s->config, "router.ciphers", 0);
 
     c2s->retry_init = j_atoi(config_get_one(c2s->config, "router.retry.init", 0), 3);
     c2s->retry_lost = j_atoi(config_get_one(c2s->config, "router.retry.lost", 0), 3);
@@ -148,6 +149,8 @@ static void _c2s_config_expand(c2s_t c2s)
     c2s->local_private_key_password = config_get_one(c2s->config, "local.private_key_password", 0);
 
     c2s->local_verify_mode = j_atoi(config_get_one(c2s->config, "local.verify-mode", 0), 0);
+
+    c2s->local_ciphers = config_get_one(c2s->config, "local.ciphers", 0);
 
     c2s->local_ssl_port = j_atoi(config_get_one(c2s->config, "local.ssl-port", 0), 0);
 
@@ -326,16 +329,18 @@ static void _c2s_hosts_expand(c2s_t c2s)
 
         host->host_private_key_password = j_attr((const char **) elem->attrs[i], "private-key-password");
 
+        host->host_ciphers = j_attr((const char **) elem->attrs[i], "ciphers");
+
 #ifdef HAVE_SSL
         if(host->host_pemfile != NULL) {
             if(c2s->sx_ssl == NULL) {
-                c2s->sx_ssl = sx_env_plugin(c2s->sx_env, sx_ssl_init, host->realm, host->host_pemfile, host->host_cachain, host->host_verify_mode, host->host_private_key_password);
+                c2s->sx_ssl = sx_env_plugin(c2s->sx_env, sx_ssl_init, host->realm, host->host_pemfile, host->host_cachain, host->host_verify_mode, host->host_private_key_password, host->host_ciphers);
                 if(c2s->sx_ssl == NULL) {
                     log_write(c2s->log, LOG_ERR, "failed to load %s SSL pemfile", host->realm);
                     host->host_pemfile = NULL;
                 }
             } else {
-                if(sx_ssl_server_addcert(c2s->sx_ssl, host->realm, host->host_pemfile, host->host_cachain, host->host_verify_mode, host->host_private_key_password) != 0) {
+                if(sx_ssl_server_addcert(c2s->sx_ssl, host->realm, host->host_pemfile, host->host_cachain, host->host_verify_mode, host->host_private_key_password, host->host_ciphers) != 0) {
                     log_write(c2s->log, LOG_ERR, "failed to load %s SSL pemfile", host->realm);
                     host->host_pemfile = NULL;
                 }
@@ -753,7 +758,7 @@ JABBER_MAIN("jabberd2c2s", "Jabber 2 C2S", "Jabber Open Source Server: Client to
 #ifdef HAVE_SSL
     /* get the ssl context up and running */
     if(c2s->local_pemfile != NULL) {
-        c2s->sx_ssl = sx_env_plugin(c2s->sx_env, sx_ssl_init, NULL, c2s->local_pemfile, c2s->local_cachain, c2s->local_verify_mode, c2s->local_private_key_password);
+        c2s->sx_ssl = sx_env_plugin(c2s->sx_env, sx_ssl_init, NULL, c2s->local_pemfile, c2s->local_cachain, c2s->local_verify_mode, c2s->local_private_key_password, c2s->local_ciphers);
         if(c2s->sx_ssl == NULL) {
             log_write(c2s->log, LOG_ERR, "failed to load local SSL pemfile, SSL will not be available to clients");
             c2s->local_pemfile = NULL;
@@ -762,7 +767,7 @@ JABBER_MAIN("jabberd2c2s", "Jabber 2 C2S", "Jabber Open Source Server: Client to
 
     /* try and get something online, so at least we can encrypt to the router */
     if(c2s->sx_ssl == NULL && c2s->router_pemfile != NULL) {
-        c2s->sx_ssl = sx_env_plugin(c2s->sx_env, sx_ssl_init, NULL, c2s->router_pemfile, c2s->router_cachain, NULL, c2s->router_private_key_password);
+        c2s->sx_ssl = sx_env_plugin(c2s->sx_env, sx_ssl_init, NULL, c2s->router_pemfile, c2s->router_cachain, NULL, c2s->router_private_key_password, c2s->router_ciphers);
         if(c2s->sx_ssl == NULL) {
             log_write(c2s->log, LOG_ERR, "failed to load router SSL pemfile, channel to router will not be SSL encrypted");
             c2s->router_pemfile = NULL;

--- a/etc/c2s.xml.dist.in
+++ b/etc/c2s.xml.dist.in
@@ -111,11 +111,14 @@
 		 SSL_VERIFY_CLIENT_ONCE          0x04
 		 Use 7 to require all clients to present _valid_ certificates.
 
-     
+         ciphers
+         List of available TLS ciphers. The format of the string is
+         described in https://www.openssl.org/docs/apps/ciphers.html
+
          cachain
-         SSL CA chain. Used to verify client certificates. 
+         SSL CA chain. Used to verify client certificates.
          CA names published to client upon connection.
-          
+
          require-starttls
          If this attribute is set to any value, clients must do STARTTLS
          before they can authenticate. Until the stream is encrypted,
@@ -188,7 +191,12 @@
     <!--
     <verify-mode>7</verify-mode>
     -->
-    
+
+    <!-- List of available TLS ciphers -->
+    <!--
+    <ciphers>DEFAULT</ciphers>
+    -->
+
     <!-- SSL CA chain. Used to verify client certificates. CA names published to client upon connection -->
     <!--
     <cachain>@sysconfdir@/client_ca_certs.pem</cachain>  

--- a/etc/s2s.xml.dist.in
+++ b/etc/s2s.xml.dist.in
@@ -122,6 +122,11 @@
     <verify-mode>7</verify-mode>
     -->
 
+    <!-- List of available TLS ciphers -->
+    <!--
+    <ciphers>DEFAULT</ciphers>
+    -->
+
     <!-- File containing an optional SSL certificate chain file for SSL
          connections. -->
     <!--

--- a/router/main.c
+++ b/router/main.c
@@ -115,6 +115,8 @@ static void _router_config_expand(router_t r)
 
     r->local_private_key_password = config_get_one(r->config, "local.private_key_password", 0);
 
+    r->local_ciphers = config_get_one(r->config, "local.ciphers", 0);
+
     r->io_max_fds = j_atoi(config_get_one(r->config, "io.max_fds", 0), 1024);
 
     elem = config_get(r->config, "io.limits.bytes");
@@ -420,7 +422,7 @@ JABBER_MAIN("jabberd2router", "Jabber 2 Router", "Jabber Open Source Server: Rou
 
 #ifdef HAVE_SSL
     if(r->local_pemfile != NULL) {
-        r->sx_ssl = sx_env_plugin(r->sx_env, sx_ssl_init, NULL, r->local_pemfile, NULL, NULL, r->local_private_key_password);
+        r->sx_ssl = sx_env_plugin(r->sx_env, sx_ssl_init, NULL, r->local_pemfile, NULL, NULL, r->local_private_key_password, r->local_ciphers);
         if(r->sx_ssl == NULL)
             log_write(r->log, LOG_ERR, "failed to load SSL pemfile, SSL disabled");
     }

--- a/router/router.h
+++ b/router/router.h
@@ -94,6 +94,7 @@ struct router_st {
     const char          *local_secret;
     const char          *local_pemfile;
     const char          *local_private_key_password;
+    const char          *local_ciphers;
 
     /** max file descriptors */
     int                 io_max_fds;

--- a/s2s/s2s.h
+++ b/s2s/s2s.h
@@ -58,6 +58,9 @@ struct host_st {
 
     /** private key password */
     char                *host_private_key_password;    
+
+    /** list of TLS ciphers */
+    const char          *host_ciphers;
 };
 
 struct s2s_st {
@@ -72,6 +75,7 @@ struct s2s_st {
     const char          *router_pemfile;
     const char          *router_cachain;
     const char          *router_private_key_password;
+    const char          *router_ciphers;
     int                 router_default;
 
     /** mio context */
@@ -133,6 +137,9 @@ struct s2s_st {
 
     /** verify-mode  */
     int                 local_verify_mode;
+
+    /** list of TLS ciphers */
+    const char          *local_ciphers;
 
     /** hosts mapping */
     xht                 hosts;

--- a/sm/main.c
+++ b/sm/main.c
@@ -127,6 +127,7 @@ static void _sm_config_expand(sm_t sm)
     sm->router_pemfile = config_get_one(sm->config, "router.pemfile", 0);
 
     sm->router_private_key_password = config_get_one(sm->config, "router.private_key_password", 0);
+    sm->router_ciphers = config_get_one(sm->config, "router.ciphers", 0);
 
     sm->retry_init = j_atoi(config_get_one(sm->config, "router.retry.init", 0), 3);
     sm->retry_lost = j_atoi(config_get_one(sm->config, "router.retry.lost", 0), 3);
@@ -372,7 +373,7 @@ JABBER_MAIN("jabberd2sm", "Jabber 2 Session Manager", "Jabber Open Source Server
 
 #ifdef HAVE_SSL
     if(sm->router_pemfile != NULL) {
-        sm->sx_ssl = sx_env_plugin(sm->sx_env, sx_ssl_init, NULL, sm->router_pemfile, NULL, NULL, sm->router_private_key_password);
+        sm->sx_ssl = sx_env_plugin(sm->sx_env, sx_ssl_init, NULL, sm->router_pemfile, NULL, NULL, sm->router_private_key_password, sm->router_ciphers);
         if(sm->sx_ssl == NULL) {
             log_write(sm->log, LOG_ERR, "failed to load SSL pemfile, SSL disabled");
             sm->router_pemfile = NULL;

--- a/sm/sm.h
+++ b/sm/sm.h
@@ -175,6 +175,7 @@ struct sm_st {
                                                  key for channel to the router */
     const char          *router_private_key_password;    /** password for private key if pemfile
                                                              key is encrypted */
+    const char          *router_ciphers;    /** TLS ciphers */
 
     mio_t               mio;                /**< mio context */
 

--- a/sx/plugins.h
+++ b/sx/plugins.h
@@ -65,7 +65,7 @@ extern "C" {
 JABBERD2_API int                         sx_ssl_init(sx_env_t env, sx_plugin_t p, va_list args);
 
 /** add cert function */
-JABBERD2_API int                         sx_ssl_server_addcert(sx_plugin_t p, const char *name, const char *pemfile, const char *cachain, int mode, const char *private_key_password);
+JABBERD2_API int                         sx_ssl_server_addcert(sx_plugin_t p, const char *name, const char *pemfile, const char *cachain, int mode, const char *private_key_password, const char *ciphers);
 
 /** trigger for client starttls */
 JABBERD2_API int                         sx_ssl_client_starttls(sx_plugin_t p, sx_t s, const char *pemfile, const char *private_key_password);


### PR DESCRIPTION
This is a rewrite of my half-baken patch (someone else submitted) which added ephemeral key support. Apart from cleaner code and removal of weak and deprecated keys, it also adds support for specifying the TLS ciphers in the configuration files.
