### PR TITLE
Compute string length before calling apr_base64_decode functions

### DIFF
--- a/util/base64.c
+++ b/util/base64.c
@@ -180,13 +180,15 @@ char *b64_encode(char *buf, int len) {
 }
 
 char *b64_decode(char *buf) {
+    int blen;
     int elen;
     char *out;
 
-    elen = apr_base64_decode_len(buf, -1);
+    blen = strlen(buf);
+    elen = apr_base64_decode_len(buf, blen);
     out = (char *) malloc(sizeof(char) * (elen + 1));
 
-    apr_base64_decode(out, buf, -1);
+    apr_base64_decode(out, buf, blen);
 
     return out;
 }


### PR DESCRIPTION
The apr_base64_decode_len and apr_base64_decode_binary functions do not
compute the length of the input string but do rely on them to compute
the number of bytes to process. In this case, the helper function
b64_decode is calling the apr_base64* functions with length of -1 which
results in buffer length checks failing and string never being decoded.