### PR TITLE
Never attempt to use non-existing blowfish i386 assembler code.

### DIFF
--- a/util/crypt_blowfish.c
+++ b/util/crypt_blowfish.c
@@ -54,14 +54,9 @@
 /* Just to make sure the prototypes match the actual definitions */
 #include "crypt_blowfish.h"
 
-#ifdef __i386__
-#define BF_ASM				1
-#define BF_SCALE			1
-#elif defined(__x86_64__) || defined(__alpha__) || defined(__hppa__)
-#define BF_ASM				0
+if defined(__x86_64__) || defined(__alpha__) || defined(__hppa__)
 #define BF_SCALE			1
 #else
-#define BF_ASM				0
 #define BF_SCALE			0
 #endif
 
@@ -518,10 +513,6 @@ static void BF_swap(BF_word *x, int count)
 	R = L; \
 	L = tmp4 ^ data.ctx.P[BF_N + 1];
 
-#if BF_ASM
-#define BF_body() \
-	_BF_body_r(&data.ctx);
-#else
 #define BF_body() \
 	L = R = 0; \
 	ptr = data.ctx.P; \
@@ -539,7 +530,6 @@ static void BF_swap(BF_word *x, int count)
 		*(ptr - 2) = L; \
 		*(ptr - 1) = R; \
 	} while (ptr < &data.ctx.S[3][0xFF]);
-#endif
 
 static void BF_set_key(const char *key, BF_key expanded, BF_key initial,
     unsigned char flags)
@@ -651,9 +641,6 @@ static char *BF_crypt(const char *key, const char *setting,
 	char *output, int size,
 	BF_word min)
 {
-#if BF_ASM
-	extern void _BF_body_r(BF_ctx *ctx);
-#endif
 	struct {
 		BF_ctx ctx;
 		BF_key expanded_key;

--- a/util/crypt_blowfish.c
+++ b/util/crypt_blowfish.c
@@ -54,7 +54,7 @@
 /* Just to make sure the prototypes match the actual definitions */
 #include "crypt_blowfish.h"
 
-if defined(__x86_64__) || defined(__alpha__) || defined(__hppa__)
+if defined(__i386__) || defined(__x86_64__) || defined(__alpha__) || defined(__hppa__)
 #define BF_SCALE			1
 #else
 #define BF_SCALE			0


### PR DESCRIPTION
This should resolve #105.  We got a similar bug report about this here which contains a bit more analysis, suggesting the problem is in jabberd2 and only manifests itself on i386's. https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=803901
