### PR TITLE
Fix memory leak in pgsql storage driver.

### DIFF
--- a/sm/mod_iq_private.c
+++ b/sm/mod_iq_private.c
@@ -176,6 +176,7 @@ static mod_ret_t _iq_private_in_sess(mod_instance_t mi, sess_t sess, pkt_t pkt) 
                     result = pkt_dup(pkt, jid_full(sscan->jid), NULL);
                     if(result->from != NULL) {
                         jid_free(result->from);
+                        result->from = NULL;
                         nad_set_attr(result->nad, 1, -1, "from", NULL, 0);
                     }
                     pkt_id_new(result);

--- a/sm/mod_privacy.c
+++ b/sm/mod_privacy.c
@@ -861,6 +861,7 @@ static mod_ret_t _privacy_in_sess(mod_instance_t mi, sess_t sess, pkt_t pkt) {
                     if(result->from != NULL) {
                         jid_free(result->from);
                         nad_set_attr(result->nad, 1, -1, "from", NULL, 0);
+                        result->from = NULL;
                     }
                     pkt_id_new(result);
                     pkt_sess(result, sscan);

--- a/storage/storage_pgsql.c
+++ b/storage/storage_pgsql.c
@@ -667,8 +667,21 @@ st_ret_t st_init(st_driver_t drv) {
         log_write(drv->st->log, LOG_ERR, "pgsql: connection to database failed: %s", PQerrorMessage(conn));
 
     if (schema) {
+        PGresult *res;
         snprintf(sql, sizeof(sql), "SET search_path TO \"%s\"", schema);
-        PQexec(conn, sql);
+        res = PQexec(conn, sql);
+
+	if (res) {
+	    if (PQResultStatus(res) != PGRES_COMMAND_OK) {
+                log_write(drv->st->log, LOG_ERR, "pgsql: unable to set search path: %s", PQResultErrorMessage(res));
+		PQclear(res);
+		return st_FAILED;
+	    }
+            PQclear(res);
+	} else {
+            log_write(drv->st->log, LOG_ERR, "pgsql: unable to set search path");
+	    return st_FAILED;
+	}
     }
 
     data = (drvdata_t) calloc(1, sizeof(struct drvdata_st));


### PR DESCRIPTION
Properly free a dangling query result, and handle errors that might occur.

...It's possible we don't care if this query fails.

Fixes bug #131 