### PR TITLE
Fix build errors with MariaDB 10.2

### DIFF
--- a/storage/authreg_mysql.c
+++ b/storage/authreg_mysql.c
@@ -487,6 +487,8 @@ DLLEXPORT int ar_init(authreg_t ar) {
     MYSQL *conn;
     mysqlcontext_t mysqlcontext;
     int fail = 0;
+    /* enable reconnect */
+    my_bool reconnect= 1;
 
     /* configure the database context with field names and SQL statements */
     mysqlcontext = (mysqlcontext_t) malloc( sizeof( struct mysqlcontext_st ) );
@@ -618,6 +620,7 @@ DLLEXPORT int ar_init(authreg_t ar) {
 
     mysql_options(conn, MYSQL_READ_DEFAULT_GROUP, "jabberd");
     mysql_options(conn, MYSQL_SET_CHARSET_NAME, "utf8");
+    mysql_options(conn, MYSQL_OPT_RECONNECT, (void *)&reconnect);
 
     /* connect with CLIENT_INTERACTIVE to get a (possibly) higher timeout value than default */
     if(mysql_real_connect(conn, host, user, pass, dbname, atoi(port), NULL, CLIENT_INTERACTIVE) == NULL) {
@@ -626,9 +629,6 @@ DLLEXPORT int ar_init(authreg_t ar) {
     }
 
     mysql_query(conn, "SET NAMES 'utf8'");
-
-    /* Set reconnect flag to 1 (set to 0 by default from mysql 5 on) */
-    conn->reconnect = 1;
 
     ar->user_exists = _ar_mysql_user_exists;
     if (MPC_PLAIN == mysqlcontext->password_type) {

--- a/storage/storage_mysql.c
+++ b/storage/storage_mysql.c
@@ -584,6 +584,8 @@ DLLEXPORT st_ret_t st_init(st_driver_t drv) {
     const char *host, *port, *dbname, *user, *pass;
     MYSQL *conn;
     drvdata_t data;
+    /* enable reconnect */
+    my_bool reconnect= 1;
 
     host = config_get_one(drv->st->config, "storage.mysql.host", 0);
     port = config_get_one(drv->st->config, "storage.mysql.port", 0);
@@ -604,6 +606,7 @@ DLLEXPORT st_ret_t st_init(st_driver_t drv) {
 
     mysql_options(conn, MYSQL_READ_DEFAULT_GROUP, "jabberd");
     mysql_options(conn, MYSQL_SET_CHARSET_NAME, "utf8");
+    mysql_options(conn, MYSQL_OPT_RECONNECT, (void *)&reconnect);
 
     /* connect with CLIENT_INTERACTIVE to get a (possibly) higher timeout value than default */
     if(mysql_real_connect(conn, host, user, pass, dbname, atoi(port), NULL, CLIENT_INTERACTIVE) == NULL) {
@@ -611,9 +614,6 @@ DLLEXPORT st_ret_t st_init(st_driver_t drv) {
         mysql_close(conn);
         return st_FAILED;
     }
-
-    /* Set reconnect flag to 1 (set to 0 by default from mysql 5 on) */
-    conn->reconnect = 1;
 
     data = (drvdata_t) calloc(1, sizeof(struct drvdata_st));
 


### PR DESCRIPTION
Building with MariaDB 10.2 gives following error:

authreg_mysql.c: In function 'ar_init':
authreg_mysql.c:631:9: error: 'MYSQL {aka struct st_mysql}' has no member named 'reconnect'
     conn->reconnect = 1;
         ^~
storage_mysql.c: In function 'st_init':
storage_mysql.c:616:9: error: 'MYSQL {aka struct st_mysql}' has no member named 'reconnect'
     conn->reconnect = 1;
         ^~

Signed-off-by: Adrian Reber <adrian@lisas.de>