### PR TITLE
Fix sigabrt due to race condition

### DIFF
--- a/c2s/c2s.c
+++ b/c2s/c2s.c
@@ -447,12 +447,14 @@ static int _c2s_client_sx_callback(sx_t s, sx_event_t e, void *data, void *arg) 
 
             /* only send a result and bring us online if this wasn't a sasl auth */
             if(strlen(s->auth_method) < 4 || strncmp("SASL", s->auth_method, 4) != 0) {
-                /* return the auth result to the client */
-                sx_nad_write(s, sess->result);
-                sess->result = NULL;
+		if(sess->result) {
+			/* return the auth result to the client */
+			sx_nad_write(s, sess->result);
+			sess->result = NULL;
 
-                /* we're good to go */
-                sess->active = 1;
+			/* we're good to go */
+			sess->active = 1;
+		}
             }
 
             /* they sasl auth'd, so we only want the new-style session start */


### PR DESCRIPTION
It seems that under big workloads a race condition is being created
and this leads to sess->result being NULL when it should not.
If sess->result is NULL and then we call

	sx_nad_write(s, sess->result);

we ended up with a SIGABRT due to a failed assertion and jabberd crashes.
This aims to protect against it by checking sess->result before
calling sx_nad_write().

I see that this is already being checked in c2s_router_sx_callback(),
but not in _c2s_client_sx_callback().